### PR TITLE
Rely on crates.io ver of ptrs instead of local

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto #default
+        threshold: 5
 
 ignore:
   - doc/

--- a/crates/lyrebird/Cargo.toml
+++ b/crates/lyrebird/Cargo.toml
@@ -27,8 +27,9 @@ test = false
 bench = false
 
 [dependencies]
-# internal crates
-ptrs = { path="../ptrs", version="0.1.0" }
+## internal crates
+# ptrs = { path="../ptrs", version="0.1.0" }
+ptrs = { version="0.1.0" }
 obfs4 = { path="../obfs4", version="0.1.0" }
 
 # shared deps

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -20,7 +20,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Local
-ptrs = { path="../ptrs", version="0.1.0" }
+# ptrs = { path="../ptrs", version="0.1.0" }
+ptrs = { version="0.1.0" }
 
 ## PRNG
 getrandom = "0.2.11"

--- a/crates/obfs4/src/test_utils/fake_prng.rs
+++ b/crates/obfs4/src/test_utils/fake_prng.rs
@@ -1,3 +1,4 @@
+
 pub(crate) struct FakePRNG<'a> {
     bytes: &'a [u8],
 }
@@ -18,10 +19,14 @@ impl<'a> rand_core::RngCore for FakePRNG<'a> {
         Ok(())
     }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        assert!(dest.len() <= self.bytes.len());
-
-        dest.copy_from_slice(&self.bytes[0..dest.len()]);
-        self.bytes = &self.bytes[dest.len()..];
+        // assert!(dest.len() <= self.bytes.len(), "dst:{} > have:{}", dest.len(), self.bytes.len());
+        if dest.len() > self.bytes.len() {
+            let mut rng = rand::thread_rng();
+            rng.fill_bytes(dest);
+        } else {
+            dest.copy_from_slice(&self.bytes[0..dest.len()]);
+            self.bytes = &self.bytes[dest.len()..];
+        }
     }
 }
 impl rand_core::CryptoRng for FakePRNG<'_> {}

--- a/crates/obfs4/src/test_utils/fake_prng.rs
+++ b/crates/obfs4/src/test_utils/fake_prng.rs
@@ -1,4 +1,3 @@
-
 pub(crate) struct FakePRNG<'a> {
     bytes: &'a [u8],
 }

--- a/crates/obfs4/src/test_utils/mod.rs
+++ b/crates/obfs4/src/test_utils/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 #![allow(dead_code)]
 
 mod fake_prng;


### PR DESCRIPTION
In preparation for pubishing the obfs4 crate to crates.io this changes the `Cargo.toml` for obfs4 to rely on the published version of `ptrs` instead of the local version.