### PR TITLE
Local crate paths for dev builds

### DIFF
--- a/crates/lyrebird/Cargo.toml
+++ b/crates/lyrebird/Cargo.toml
@@ -28,8 +28,7 @@ bench = false
 
 [dependencies]
 ## internal crates
-# ptrs = { path="../ptrs", version="0.1.0" }
-ptrs = { version="0.1.0" }
+ptrs = { path="../ptrs", version="0.1.0" }
 obfs4 = { path="../obfs4", version="0.1.0" }
 
 # shared deps

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -20,8 +20,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ## Local
-# ptrs = { path="../ptrs", version="0.1.0" }
-ptrs = { version="0.1.0" }
+ptrs = { path="../ptrs", version="0.1.0" }
+
 
 ## PRNG
 getrandom = "0.2.11"


### PR DESCRIPTION
We don't have to remove local alts (`path=...`) for build / publish, it uses `version` for those by default.