### PR TITLE
Update `actions/checkout` from v3 to v4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     name: Verify code Fromatting
     runs-on: "ubuntu-latest"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Format
       run: cargo fmt --all -- --check
 
@@ -31,7 +31,7 @@ jobs:
       RUSTFLAGS: -Dwarnings
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly
@@ -48,7 +48,7 @@ jobs:
 #       name: Check that benchmarks compile
 #       runs-on: ubuntu-latest
 #       steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #       - uses: dtolnay/rust-toolchain@stable
 #       - name: Build u32 bench
 #         env:
@@ -78,7 +78,7 @@ jobs:
           # 64-bit target
           - target: x86_64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - run: rustup target add ${{ matrix.target }}
     - run: ${{ matrix.deps }}
@@ -90,7 +90,7 @@ jobs:
     name: Test Nightly
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo test --workspace --all-targets
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
Update from old gh action for checkout because actions are shifting from node16 to node20.