### PR TITLE
Out of date deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ MSRV can be changed in the future, but it will be done with a minor version bump
 
 Things to keep an eye on:
 
-- [ ] PR implementating elligator2 for the `dalek` ed25519 library. [PR Here](https://github.com/dalek-cryptography/ptrs/pull/612)
+- [ ] PR implementating elligator2 for the `dalek` ed25519 library. [PR Here](https://github.com/dalek-cryptography/curve25519-dalek/pull/612)
 
 ## Open Source License
 

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -19,5 +19,9 @@ x25519-dalek = { version = "2", features = ["static_secrets", "getrandom", "reus
 zeroize = "1.7.0"
 
 [dev-dependencies]
+hex = "0.4.3"
+anyhow = "1.0"
+
 # o5 pqc test
-pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
+# pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
+ml-kem = "0.1.0"

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -7,15 +7,12 @@ mod framing;
 // mod handshake;
 // mod transport;
 
-
-
 #[cfg(test)]
 #[allow(unused)]
 mod ml_kem_tests {
+    use anyhow::{anyhow, Context, Result};
     use ml_kem::*;
     use x25519_dalek::{EphemeralSecret, PublicKey};
-    use anyhow::{anyhow, Context, Result};
-
 
     struct Kyber1024XKeypair {}
 
@@ -26,7 +23,7 @@ mod ml_kem_tests {
     }
 
     #[test]
-    fn it_works() -> Result<()>  {
+    fn it_works() -> Result<()> {
         let mut rng = rand::thread_rng();
 
         // --- Generate Keypair (Alice) ---
@@ -34,7 +31,7 @@ mod ml_kem_tests {
         let alice_secret = EphemeralSecret::random_from_rng(&mut rng);
         let alice_public = PublicKey::from(&alice_secret);
         // kyber
-        let (alice_kyber_dk, alice_kyber_ek) =  MlKem1024::generate(&mut rng);
+        let (alice_kyber_dk, alice_kyber_ek) = MlKem1024::generate(&mut rng);
 
         // --- alice -> bob (public keys) ---
         // alice sends bob the public key for her kyber1024 keypair with her
@@ -62,7 +59,11 @@ mod ml_kem_tests {
 
         assert_eq!(alice_shared_secret.as_bytes(), bob_shared_secret.as_bytes());
         assert_eq!(shared_secret_bob, shared_secret_alice);
-        println!("{} ?= {}", hex::encode(shared_secret_bob), hex::encode(shared_secret_alice));
+        println!(
+            "{} ?= {}",
+            hex::encode(shared_secret_bob),
+            hex::encode(shared_secret_alice)
+        );
 
         Ok(())
     }

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -81,4 +81,5 @@ hex-literal = "0.4.1"
 tor-basic-utils = "0.18.0"
 
 # o5 pqc test
-pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
+# pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
+# ml-kem = "0.1.0"

--- a/crates/ptrs/Cargo.toml
+++ b/crates/ptrs/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.30"
 itertools = "0.12.1"
 subtle = "2.5.0"
 thiserror = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.33", features = ["full"] }
 tracing = "0.1.40"
 url = "2.5.0"
 


### PR DESCRIPTION
Based on [deps.rs](https://deps.rs/repo/github/jmwample/ptrs) there were two packages with known vulns. 

`tokio`  - just needed to enforce a newer version (i.e. `"1" -> "1.33"`)
[`pqc_kyber`](https://docs.rs/pqc_kyber/latest/pqc_kyber/) - has a [non-constant time bug that has not been patched](https://github.com/Argyle-Software/kyber/issues/108). I am swapping to the [`ml_kem`](https://docs.rs/ml-kem/latest/ml_kem/) crate for now which which has this specific issue handled.