### PR TITLE
Establish an MSRV and add a CI test to ensure compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
     - run: cargo test --workspace --all-targets
 
   msrv:
-    name: Current MSRV is 1.74.0
+    name: Check Crates against MSRV
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -103,11 +103,15 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo update -Z minimal-versions
     # Now check that `cargo build` works with respect to the oldest possible
-    # deps and the stated MSRV
-    - uses: dtolnay/rust-toolchain@1.74.0
-    - run: cargo build --no-default-features
+    # deps and the stated MSRV. 1.70 should work for all
+    - uses: dtolnay/rust-toolchain@1.70.0
+    - run: cargo test --workspace --all-targets --all-features
     # Also make sure the AVX2 build works
     - run: cargo build --target x86_64-unknown-linux-gnu
+    # The PTRS crate has fewer dependencies and a lower msrv
+    - uses: dtolnay/rust-toolchain@1.63
+    - run: cargo test -p ptrs --all-targets --all-features
+    - run: cargo build -p ptrs --target x86_64-unknown-linux-gnu
 
   build:
     name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,9 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # Re-resolve Cargo.lock with minimal versions
-    - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo update -Z minimal-versions
+    # # Re-resolve Cargo.lock with minimal versions
+    # - uses: dtolnay/rust-toolchain@nightly
+    # - run: cargo update -Z minimal-versions
+
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
     - uses: dtolnay/rust-toolchain@1.74.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,10 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    # # Re-resolve Cargo.lock with minimal versions
-    # - uses: dtolnay/rust-toolchain@nightly
-    # - run: cargo update -Z minimal-versions
-
+    # Re-resolve Cargo.lock with minimal versions
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo update -Z minimal-versions
     # Now check that `cargo build` works with respect to the oldest possible
     # deps and the stated MSRV
     - uses: dtolnay/rust-toolchain@1.74.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,21 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo test --workspace --all-targets
 
+  msrv:
+    name: Current MSRV is 1.74.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    # Re-resolve Cargo.lock with minimal versions
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo update -Z minimal-versions
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV
+    - uses: dtolnay/rust-toolchain@1.74.0
+    - run: cargo build --no-default-features
+    # Also make sure the AVX2 build works
+    - run: cargo build --target x86_64-unknown-linux-gnu
+
   build:
     name: Build
     needs: format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 members = [
     "crates/lyrebird",
-    "crates/o5",
+    # "crates/o5",
     "crates/o7",
     "crates/obfs4",
     "crates/ptrs",

--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ lyrebird binary, and Pluggable Transports in Rust (PTRS) library.
 
 ## MSRV
 
-The planned Minimum Supported Rust Version (MSRV) is 1.60, however there is no
-current testing to ensure that this is working currently.
+The Minimum Supported Rust Versions (MSRV) for the various crates are listed above.
+These are ensured by test and build steps in the CI pipeline. 
 
 MSRV can be changed in the future, but it will be done with a minor version bump.
+We will not increase MSRV on PATCH releases, though downstream dependencies might.
+
+We won't increase MSRV just because we can: we'll only do so when we have a
+reason. (We don't guarantee that you'll agree with our reasoning; only that
+it will exist.)
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ This repository contains multiple related crates implementing the lyrebird (obfs
 lyrebird binary, and Pluggable Transports in Rust (PTRS) library.
 
 
-|                 Crate                    |   Description  | Crates.io | Docs |
--------------------------------------------|----------------|-----------|------|
-| [`ptrs`](./crates/ptrs) | A library supporting implementation and integration of Pluggable Transport protocols. | [![](https://img.shields.io/crates/v/ptrs.svg)](https://crates.io/crates/ptrs) | [![](https://img.shields.io/docsrs/ptrs)](https://docs.rs/ptrs) |
-| [`lyrebird`](./crates/lyrebird) | Implementation of the `Lyrebird` Tor bridge and a forward proxy compatible with `ptrs`. | [![](https://img.shields.io/crates/v/lyrebird.svg)](https://crates.io/crates/lyrebird) | [![](https://docs.rs/lyrebird/badge.svg)](https://docs.rs/lyrebird) |
-| [`obfs4`](./crates/obfs4) | An implementation of obfs4 pluggable transport library in pure rust. | [![](https://img.shields.io/crates/v/obfs4.svg)](https://crates.io/crates/obfs4) | [![](https://docs.rs/obfs4/badge.svg)](https://docs.rs/obfs4) |
+|                 Crate                    |   Description  | Crates.io | Docs | MSRV |
+-------------------------------------------|----------------|-----------|------|------|
+| [`ptrs`](./crates/ptrs) | A library supporting implementation and integration of Pluggable Transport protocols. | [![](https://img.shields.io/crates/v/ptrs.svg)](https://crates.io/crates/ptrs) | [![](https://img.shields.io/docsrs/ptrs)](https://docs.rs/ptrs) | 1.63 |
+| [`lyrebird`](./crates/lyrebird) | Implementation of the `Lyrebird` Tor bridge and a forward proxy compatible with `ptrs`. | [![](https://img.shields.io/crates/v/lyrebird.svg)](https://crates.io/crates/lyrebird) | [![](https://docs.rs/lyrebird/badge.svg)](https://docs.rs/lyrebird) | 1.70 |
+| [`obfs4`](./crates/obfs4) | An implementation of obfs4 pluggable transport library in pure rust. | [![](https://img.shields.io/crates/v/obfs4.svg)](https://crates.io/crates/obfs4) | [![](https://docs.rs/obfs4/badge.svg)](https://docs.rs/obfs4) | 1.70 |
 
 ## MSRV
 

--- a/crates/lyrebird/Cargo.toml
+++ b/crates/lyrebird/Cargo.toml
@@ -35,7 +35,7 @@ obfs4 = { path="../obfs4", version="0.1.0" }
 
 # fwd deps
 anyhow = "1.0"
-clap = { version = "4.4.7", features = ["derive"]}
+clap = { version = "4.4", features = ["derive"]}
 fast-socks5 = "0.9.1"
 futures = "0.3.29"
 safelog = "0.3.5"

--- a/crates/lyrebird/Cargo.toml
+++ b/crates/lyrebird/Cargo.toml
@@ -40,7 +40,7 @@ fast-socks5 = "0.9.1"
 futures = "0.3.29"
 safelog = "0.3.5"
 thiserror = "1.0.56"
-tokio = { version = "1.37", features = ["io-util", "net", "macros", "sync", "signal"] }
+tokio = { version = "1.34", features = ["io-util", "net", "macros", "sync", "signal"] }
 tokio-util = "0.7.10"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/lyrebird/Cargo.toml
+++ b/crates/lyrebird/Cargo.toml
@@ -40,7 +40,7 @@ fast-socks5 = "0.9.1"
 futures = "0.3.29"
 safelog = "0.3.5"
 thiserror = "1.0.56"
-tokio = { version = "1.33", features = ["io-util", "net", "macros", "sync", "signal"] }
+tokio = { version = "1.37", features = ["io-util", "net", "macros", "sync", "signal"] }
 tokio-util = "0.7.10"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/lyrebird/src/fwd/backend.rs
+++ b/crates/lyrebird/src/fwd/backend.rs
@@ -7,8 +7,8 @@ use tokio::net::TcpStream;
 
 use std::net::SocketAddr;
 use std::ops::Deref;
-use std::sync::Arc;
 use std::pin::Pin;
+use std::sync::Arc;
 
 pub(crate) trait Backend {
     /// The provided In must be usable as a connection in an async context.
@@ -71,7 +71,6 @@ impl BackendArc {
     }
 }
 
-
 impl Deref for BackendArc {
     type Target = Backends;
     fn deref(&self) -> &Self::Target {
@@ -80,7 +79,11 @@ impl Deref for BackendArc {
 }
 
 impl Backend for BackendArc {
-    fn handle<In>(&self, conn: In, client_addr: SocketAddr) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + '_>>
+    fn handle<In>(
+        &self,
+        conn: In,
+        client_addr: SocketAddr,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + Sync + '_>>
     where
         In: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
     {

--- a/crates/lyrebird/src/fwd/main.rs
+++ b/crates/lyrebird/src/fwd/main.rs
@@ -336,7 +336,7 @@ async fn client_accept_loop<C>(
 ) -> Result<()>
 where
     // the provided client builder should build the C ClientTransport.
-    C: ptrs::ClientTransport<TcpStream, std::io::Error> + 'static,
+    C: ptrs::ClientTransport<TcpStream, std::io::Error> + Send + 'static,
 {
     let pt_name = C::method_name();
     let builder = builder.options(&params)?;

--- a/crates/lyrebird/src/main.rs
+++ b/crates/lyrebird/src/main.rs
@@ -316,7 +316,7 @@ async fn client_accept_loop<C>(
 ) -> Result<()>
 where
     // the provided client builder should build the C ClientTransport.
-    C: ptrs::ClientTransport<TcpStream, std::io::Error> + 'static,
+    C: ptrs::ClientTransport<TcpStream, std::io::Error> + Send + 'static,
 {
     let pt_name = C::method_name();
     loop {
@@ -351,7 +351,7 @@ where
     // the provided T must be usable as a connection in an async context
     In: AsyncRead + AsyncWrite + Send + Unpin,
     // the provided client builder should build the C ClientTransport.
-    C: ptrs::ClientTransport<TcpStream, std::io::Error>,
+    C: ptrs::ClientTransport<TcpStream, std::io::Error> + Send,
 {
     let mut config: fast_socks5::server::Config<SimpleUserPassword> =
         fast_socks5::server::Config::default();

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -13,7 +13,7 @@ rand = { version="0.8.5", features=["getrandom"]}
 rand_core = "0.6.4"
 
 subtle = "2.5.0"
-x25519-dalek = { version = "2", features = ["static_secrets", "getrandom", "reusable_secrets", "elligator2"],  git = "https://github.com/jmwample/curve25519-dalek.git", branch = "elligator2-ntor"}
+x25519-dalek = { version = "2.0.1", features = ["static_secrets", "getrandom", "reusable_secrets", "elligator2"],  git = "https://github.com/jmwample/curve25519-dalek.git", branch = "elligator2-ntor"}
 
 # ntor_arti
 zeroize = "1.7.0"

--- a/crates/o7/Cargo.toml
+++ b/crates/o7/Cargo.toml
@@ -24,4 +24,4 @@ ptrs = { path="../ptrs", version="0.1.0" }
 
 ## Networking tools
 tokio = { version = "1.33", features = ["io-util", "rt-multi-thread", "net", "rt", "macros", "sync", "signal", "time", "fs"] }
-tokio-util = { version = "0.7.10", features = ["codec", "io", "net"]}
+# tokio-util = { version = "0.7.10", features = ["codec", "io", "net"]}

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -49,7 +49,7 @@ serde = "1.0.197"
 ## Networking tools
 pin-project = "1.1.3"
 futures = "0.3.29"
-tokio = { version = "1.37", features = ["io-util", "rt-multi-thread", "net", "rt", "macros", "sync", "signal", "time", "fs"] }
+tokio = { version = "1.34", features = ["io-util", "rt-multi-thread", "net", "rt", "macros", "sync", "signal", "time", "fs"] }
 tokio-util = { version = "0.7.10", features = ["codec", "io"]}
 bytes = "1.5.0"
 
@@ -62,7 +62,7 @@ cipher = "0.4.4"
 zeroize = "1.7.0"
 thiserror = "1.0.56"
 
-## transative dependencies that break things when versions are too low
+## transitive dependencies that break things when versions are too low
 ## i.e. any lower than the exact versions here.
 curve25519-dalek = { version="4.1.2", optional=true}
 anyhow = { version="1.0.20", optional=true}

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -36,7 +36,7 @@ hmac = { version="0.12.1", features=["reset"]}
 hkdf = "0.12.3"
 crypto_secretbox = { version="0.1.1", features=["salsa20"]}
 subtle = "2.5.0"
-x25519-dalek = { version = "2", features = ["static_secrets", "getrandom", "reusable_secrets", "elligator2"],  git = "https://github.com/jmwample/curve25519-dalek.git", branch = "elligator2-ntor"}
+x25519-dalek = { version = "2.0.1", features = ["static_secrets", "getrandom", "reusable_secrets", "elligator2"],  git = "https://github.com/jmwample/curve25519-dalek.git", branch = "elligator2-ntor"}
 
 ## Utils
 hex = "0.4.3"
@@ -62,13 +62,13 @@ cipher = "0.4.4"
 zeroize = "1.7.0"
 thiserror = "1.0.56"
 
-# fwd
-fast-socks5 = "0.9.1"
-url = "2.5.0"
-anyhow = "1.0"
-tracing-subscriber = "0.3.18"
-clap = { version = "4.4", features = ["derive"]}
-safelog = { version = "0.3.5" }
+## transative dependencies that break things when versions are too low
+## i.e. any lower than the exact versions here.
+curve25519-dalek = { version="4.1.2", optional=true}
+anyhow = { version="1.0.20", optional=true}
+async-trait = { version="0.1.9", optional=true}
+num-bigint = { version="0.4.2", optional=true}
+simple_asn1 = { version="0.6.1", optional=true}
 
 ## Maybe useful in future iterations
 # tor-socksproto = { version = "0.10.0" }
@@ -83,3 +83,4 @@ tor-basic-utils = "0.18.0"
 # o5 pqc test
 # pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
 # ml-kem = "0.1.0"
+

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -67,7 +67,7 @@ fast-socks5 = "0.9.1"
 url = "2.5.0"
 anyhow = "1.0"
 tracing-subscriber = "0.3.18"
-clap = { version = "4.4.7", features = ["derive"]}
+clap = { version = "4.4", features = ["derive"]}
 safelog = { version = "0.3.5" }
 
 ## Maybe useful in future iterations

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -49,7 +49,7 @@ serde = "1.0.197"
 ## Networking tools
 pin-project = "1.1.3"
 futures = "0.3.29"
-tokio = { version = "1.33", features = ["io-util", "rt-multi-thread", "net", "rt", "macros", "sync", "signal", "time", "fs"] }
+tokio = { version = "1.37", features = ["io-util", "rt-multi-thread", "net", "rt", "macros", "sync", "signal", "time", "fs"] }
 tokio-util = { version = "0.7.10", features = ["codec", "io"]}
 bytes = "1.5.0"
 

--- a/crates/obfs4/src/sessions.rs
+++ b/crates/obfs4/src/sessions.rs
@@ -36,7 +36,7 @@ pub(crate) struct Established;
 /// The session broke due to something like a timeout, reset, lost connection, etc.
 trait Fault {}
 
-pub enum Session {
+pub(crate) enum Session {
     Client(ClientSession<Established>),
     Server(ServerSession<Established>),
 }
@@ -140,7 +140,7 @@ impl<S: ClientSessionState> ClientSession<S> {
     }
 }
 
-pub fn new_client_session(
+pub(crate) fn new_client_session(
     station_pubkey: Obfs4NtorPublicKey,
     iat_mode: IAT,
 ) -> ClientSession<Initialized> {

--- a/crates/ptrs/Cargo.toml
+++ b/crates/ptrs/Cargo.toml
@@ -3,7 +3,7 @@ name = "ptrs"
 version = "0.1.0"
 edition = "2021"
 authors = ["Jack Wampler <jack.wampler@colorado.edu>"]
-rust-version = "1.70"
+rust-version = "1.63"
 license = "MIT OR Apache-2.0"
 description = "Interdaces and utilities supporting pluggable transport implementations"
 keywords = ["tor", "censorship", "pluggable", "transports"]
@@ -24,7 +24,7 @@ futures = "0.3.30"
 itertools = "0.12.1"
 subtle = "2.5.0"
 thiserror = "1"
-tokio = { version = "1.37", features = ["full"] }
+tokio = { version = "1.34", features = ["full"] }
 tracing = "0.1.40"
 url = "2.5.0"
 

--- a/crates/ptrs/Cargo.toml
+++ b/crates/ptrs/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.30"
 itertools = "0.12.1"
 subtle = "2.5.0"
 thiserror = "1"
-tokio = { version = "1.33", features = ["full"] }
+tokio = { version = "1.37", features = ["full"] }
 tracing = "0.1.40"
 url = "2.5.0"
 

--- a/crates/ptrs/src/passthrough.rs
+++ b/crates/ptrs/src/passthrough.rs
@@ -590,13 +590,14 @@ mod design_tests {
                 <<B as ServerBuilder<T>>::ServerPT as ServerTransport<T>>::OutErr,
             >,
         >,
-        Box<dyn std::error::Error>,
+        Box<dyn std::error::Error + Send + Sync>,
     >
     where
         T: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
         B: ServerBuilder<T>,
         B::ServerPT: ServerTransport<T>,
         B::Error: std::error::Error + 'static,
+        <B as ServerBuilder<T>>::Error: std::error::Error + Send + Sync,
     {
         Ok(pt_builder
             .statefile_location("./")?


### PR DESCRIPTION
This PR tries to establish a ground level for the Minimum Supported Rust Version (MSRV).

This has required a few things.
1. Disable o5 crate in the workspace `Cargo.toml`
    * o5 requires the `ml_kem` package at the moment which forces an msrv of 1.74, but we can do better.
2. Test with the minimum version of **ALL** dependencies
    * This includes transitive dependencies
        - several of these actually allow dependencies of old enough version that it breaks things
        - to fix this I manually found the exact minimum acceptable version of those crates and added it to the `Cargo.toml` of the (internal) crate that uses them. 
3.  Downgrade some of the patterns that I am using to implement things that aren't supported in older versions of rustc.
    * For example a trait with a function whose return contains an `impl`

With all of this we are left with the msrv of 1.70 as the `tor-*` (`tor-bytes`, `tor-cell`, etc.) have an msrv of 1.70 and cannot be downgraded without allowing some critical vulnerability.