### PR TITLE
Configuring Unexpected cfgs

### DIFF
--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -25,3 +25,9 @@ anyhow = "1.0"
 # o5 pqc test
 # pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
 ml-kem = "0.1.0"
+
+[lints.rust]
+# unexpected_cfgs are used to disable incomplete / WIP features and tests. This is
+# not an error for this library. This turns off that specific lint for the "disable" feature.
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_features, values("disabled"))'] }
+

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc = include_str!("../README.md")]
-// unexpected_cfgs are used to disable incomplete / WIP features and tests. This is
-// not an error for this library.
-#![allow(unexpected_cfgs)]
+
 
 mod framing;
 // mod handshake;

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -89,3 +89,8 @@ tor-basic-utils = "0.20.0"
 # pqc_kyber = {version="0.7.1", features=["kyber1024", "std"]}
 # ml-kem = "0.1.0"
 
+[lints.rust]
+# unexpected_cfgs are used to disable incomplete / WIP features and tests. This is
+# not an error for this library. This turns off that specific lint for the "disable" feature.
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_features, values("disabled"))'] }
+

--- a/crates/obfs4/src/common/x25519_elligator2.rs
+++ b/crates/obfs4/src/common/x25519_elligator2.rs
@@ -362,13 +362,15 @@ mod test {
 
     #[test]
     fn off_subgroup_check_edw() {
+        let mut count = 0;
+        let n_trials = 100;
         let mut rng = rand::thread_rng();
-        for _ in 0..100 {
+        for _ in 0..n_trials {
             let (repr, pk) = generate(&mut rng);
 
             // check if the generated public key is off the subgroup
             let v = scalar_mult_order(&pk);
-            let pk_off = !v.is_identity();
+            let _pk_off = !v.is_identity();
 
             // ----
 
@@ -390,7 +392,12 @@ mod test {
             let v = scalar_mult_order(&pk_254);
             let off_254 = !v.is_identity();
 
-            println!("pk_gen: {pk_off}, pk_255: {off_255}, pk_254: {off_254}");
+            // println!("pk_gen: {pk_off}, pk_255: {off_255}, pk_254: {off_254}");
+            if off_254 &&off_255  {
+                count +=1;
+            }
         }
+        assert!(count > 0);
+        assert!(count < n_trials);
     }
 }

--- a/crates/obfs4/src/common/x25519_elligator2.rs
+++ b/crates/obfs4/src/common/x25519_elligator2.rs
@@ -393,8 +393,8 @@ mod test {
             let off_254 = !v.is_identity();
 
             // println!("pk_gen: {pk_off}, pk_255: {off_255}, pk_254: {off_254}");
-            if off_254 &&off_255  {
-                count +=1;
+            if off_254 && off_255 {
+                count += 1;
             }
         }
         assert!(count > 0);

--- a/crates/obfs4/src/lib.rs
+++ b/crates/obfs4/src/lib.rs
@@ -1,12 +1,4 @@
 #![doc = include_str!("../README.md")]
-// unexpected_cfgs are used to disable incomplete / WIP features and tests. This is
-// not an error for this library.
-#![allow(unexpected_cfgs)]
-
-// #![feature(trait_alias)]
-
-// #![allow(dead_code)]
-// #![allow(warnings)]
 
 pub mod client;
 pub mod common;


### PR DESCRIPTION
A recent version of rust (I am not sure exactly which) added a check to ensure that all features used in the crate are defined in the `Cargo.toml`. This caused an error / warning for me because I am using a feature  not named in the `Cargo.toml` called "disabled" to remove certain unfinished, long-running, or inaccurate tests (that I don't want to fully remove) from the compiled test harness.

Previously I was doing this by broadly disabling the `unexpected_cfg` check entirely for the crate using:
```rs
#![allow(unexpected_cfgs)]
```

With updates included in nightly there is a better solution to this. Which is to inform the compiler of any used, but undeclared features so that any that would be unexpected must be intentional. And the check can catch unintentional unused cfgs for you.

```yml
[lints.rust]
unexpected_cfgs = { level = "allow", check-cfg = ['cfg(target_features, values("disabled"))'] }
```

thanks to @Urgau for pointing this out in #38