### PR TITLE
Adapt to Using X-Wing Keys

### DIFF
--- a/crates/lyrebird/src/fwd/main.rs
+++ b/crates/lyrebird/src/fwd/main.rs
@@ -449,9 +449,7 @@ where
     let client_options = builder.get_client_params();
     let server = builder.build();
 
-    info!(
-        "({obfs4_name}) client params: \"{}\"", client_options
-    );
+    info!("({obfs4_name}) client params: \"{}\"", client_options);
 
     let listener = tokio::net::TcpListener::bind(listen_addrs).await?;
     listeners.push(server_listen_loop::<TcpStream, _, _>(

--- a/crates/lyrebird/src/fwd/main.rs
+++ b/crates/lyrebird/src/fwd/main.rs
@@ -442,15 +442,15 @@ where
     let mut listeners = Vec::new();
 
     let mut builder = Obfs4PT::server_builder();
-    let server = if params.is_some() {
-        builder.options(&params.unwrap())?.build()
-    } else {
-        builder.build()
-    };
+    if params.is_some() {
+        builder.options(&params.unwrap())?;
+    }
+
+    let client_options = builder.get_client_params();
+    let server = builder.build();
 
     info!(
-        "({obfs4_name}) client params: \"{}\"",
-        builder.get_client_params()
+        "({obfs4_name}) client params: \"{}\"", client_options
     );
 
     let listener = tokio::net::TcpListener::bind(listen_addrs).await?;

--- a/crates/lyrebird/src/main.rs
+++ b/crates/lyrebird/src/main.rs
@@ -527,10 +527,10 @@ async fn server_setup(
         }
 
         let mut builder = Obfs4PT::server_builder();
-        let server = builder
+        builder
             .statefile_location(statedir)?
-            .options(&bind_addr.options)?
-            .build();
+            .options(&bind_addr.options)?;
+        let server = builder.build();
 
         let listener = tokio::net::TcpListener::bind(bind_addr.addr).await?;
         listeners.push(server_listen_loop::<TcpStream, _>(

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -35,6 +35,7 @@ hkdf = "0.12.3"
 crypto_secretbox = { version="0.1.1", features=["chacha20"]}
 subtle = "2.5.0"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets", "getrandom", "reusable_secrets"]}
+x-wing = "0.0.1-alpha"
 
 ## Utils
 pin-project = "1.1.3"

--- a/crates/o5/README.md
+++ b/crates/o5/README.md
@@ -18,29 +18,30 @@ date elements without worrying about being backward compatible.
     - the concept of "packets" is now called "messages"
     - a frame can contain multiple messages
     - update from xsalsa20poly1305 -> chacha20poly1305
-    - padding is given an explicit message type different than that of a payload and uses the mesage length header field
+    - padding is given an explicit message type different than that of a payload message and uses the mesage length header field
       - (In obfs4 a frame that decodes to a payload packet type `\x00` with packet length 0 is asummed to all be padding)
       - move payload to message type `\x01`
       - padding takes message type `\x00`
     - (Maybe) add bidirectional heartbeat messages
+
 - Handshake
-  - x25519 key-exchange -> Kyber1024X25519 key-exchange
+  - x25519 key-exchange -> [X-Wing](https://datatracker.ietf.org/doc/html/draft-connolly-cfrg-xwing-kem#name-with-hpke-x25519kyber768dra) (ML-KEM + X25519) Hybrid Public Key Exchange
     - the overhead padding of the current obfs4 handshake (resulting in paket length in [4096:8192]) is mostly unused
     we exchange some of this unused padding for a kyber key to provide post-quantum security to the handshake.
-    - Are Kyber1024 keys uniform random? I assume not.
-  - NTor V3 handshake
-    - the obfs4 handshake uses (a custom version of) the ntor handshake to derive key materials
-  - (Maybe) change mark and MAC from sha256-128 to sha256
-  - handshake parameters encrypted under the key exchange public keys
+    - [Kemeleon Encoding](https://docs.rs/kemeleon/latest/kemeleon/) for obfuscating ML-KEM public keys and ciphertext on the wire.
+    - [Elligator2](https://docs.rs/curve25519-elligator2/latest/curve25519_elligator2/) for obfuscating X25519 public keys.
+  - [PQ-Obfs handshake](https://eprint.iacr.org/2024/1086.pdf)
+    - Adapted from the [NTor V3 handshake](https://spec.torproject.org/proposals/332-ntor-v3-with-extra-data.html)
+  - Change mark and MAC from sha256-128 to sha3-256
+  - Allow messages extra data to be sent with the handshake, encrypted under the key exchange public keys
     - the client can provide initial parameters during the handshake, knowing that they are not forward secure.
     - the server can provide messages with parameters / extensions in the handshake response (like prngseed)
-    - like the kyber key, this takes space out of the padding already used in the client handshake.
+    - This takes space out of the padding already used in the client handshake.
   - (Maybe) session tickets and resumption
-  - (Maybe) handshake complete frame type
 
 ### Goals
+* Post Quantum Forward Secrecy - traffic captured today cannot be decrypted by a quantum computer tomorrow.
 * Stick closer to Codec / Framed implementation for all packets (hadshake included)
-* use the tor/arti ntor v3 implementation
 
 ### Features to keep
 - once a session is established, unrecognized frame types are ignored

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use crate::{
-    common::{colorize, mlkem1024_x25519, HmacSha256},
+    common::{colorize, xwing, HmacSha256},
     constants::*,
     framing::{FrameError, Marshall, O5Codec, TryParse, KEY_LENGTH, KEY_MATERIAL_LENGTH},
     handshake::IdentityPublicKey,
@@ -26,8 +26,7 @@ use std::{
 
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
-    pub station_pubkey: [u8; PUBLIC_KEY_LEN],
-    pub station_id: [u8; NODE_ID_LENGTH],
+    pub node_details: IdentityPublicKey,
     pub statefile_path: Option<String>,
     pub(crate) handshake_timeout: MaybeTimeout,
 }
@@ -35,8 +34,8 @@ pub struct ClientBuilder {
 impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
-            station_pubkey: [0u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])
+                .expect("default identitykey is broken - shouldn't be used anyways"),
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         }
@@ -46,9 +45,9 @@ impl Default for ClientBuilder {
 impl ClientBuilder {
     /// TODO: implement client builder from statefile
     pub fn from_statefile(location: &str) -> Result<Self> {
+        todo!("this is not implemented");
         Ok(Self {
-            station_pubkey: [0_u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
             statefile_path: Some(location.into()),
             handshake_timeout: MaybeTimeout::Default_,
         })
@@ -56,16 +55,21 @@ impl ClientBuilder {
 
     /// TODO: implement client builder from string args
     pub fn from_params(param_strs: Vec<impl AsRef<[u8]>>) -> Result<Self> {
+        todo!("this is not implemented");
         Ok(Self {
-            station_pubkey: [0_u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         })
     }
 
-    pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> &mut Self {
-        self.station_pubkey = pubkey;
+    pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> Result<&mut Self> {
+        self.node_details.pk = xwing::PublicKey::try_from(&pubkey[..])?;
+        Ok(self)
+    }
+
+    pub(crate) fn with_node(&mut self, pubkey: IdentityPublicKey) -> &mut Self {
+        self.node_details = pubkey;
         self
     }
 
@@ -75,7 +79,7 @@ impl ClientBuilder {
     }
 
     pub fn with_node_id(&mut self, id: [u8; NODE_ID_LENGTH]) -> &mut Self {
-        self.station_id = id;
+        self.node_details.id = id.into();
         self
     }
 
@@ -96,8 +100,7 @@ impl ClientBuilder {
 
     pub fn build(&self) -> Client {
         Client {
-            station_pubkey: IdentityPublicKey::new(self.station_pubkey, self.station_id)
-                .expect("failed to build client - bad options."),
+            station_pubkey: self.node_details.clone(),
             handshake_timeout: self.handshake_timeout.duration(),
         }
     }

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -64,7 +64,7 @@ impl ClientBuilder {
     }
 
     pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> Result<&mut Self> {
-        self.node_details.pk = xwing::PublicKey::try_from(&pubkey[..])?;
+        self.node_details.ek = xwing::EncapsulationKey::try_from(&pubkey[..])?;
         Ok(self)
     }
 

--- a/crates/o5/src/common/mod.rs
+++ b/crates/o5/src/common/mod.rs
@@ -12,11 +12,11 @@ mod skip;
 pub use skip::discard;
 
 pub mod drbg;
-pub mod mlkem1024_x25519;
 pub mod ntor_arti;
 pub mod probdist;
 pub mod replay_filter;
 pub mod x25519_elligator2;
+pub mod xwing;
 
 pub trait ArgParse {
     type Output;

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -13,10 +13,10 @@
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 use crate::{
-    common::{colorize, mlkem1024_x25519},
+    common::{colorize, xwing},
     Error, Result,
 };
-//use zeroize::Zeroizing;
+
 use tor_bytes::SecretBuf;
 
 pub const SESSION_ID_LEN: usize = 8;
@@ -70,10 +70,8 @@ pub trait ClientHandshake {
     type HandshakeMaterials: ClientHandshakeMaterials;
     /// The type for the state that the client holds while waiting for a reply.
     type StateType;
-    /// A type that is returned and used to generate session keys.x
-    type KeyGen;
     /// Type of extra data returned by server (without forward secrecy).
-    type ServerAuxData;
+    type HsOutput: ClientHandshakeComplete;
 
     /// Generate a new client onionskin for a relay with a given onion key,
     /// including `client_aux_data` to be sent without forward secrecy.
@@ -81,15 +79,22 @@ pub trait ClientHandshake {
     /// On success, return a state object that will be used to
     /// complete the handshake, along with the message to send.
     fn client1(materials: Self::HandshakeMaterials) -> Result<(Self::StateType, Vec<u8>)>;
+
     /// Handle an onionskin from a relay, and produce aux data returned
     /// from the server, and a key generator.
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(
-        state: Self::StateType,
-        msg: T,
-    ) -> Result<(Self::ServerAuxData, Self::KeyGen)>;
+    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
+}
+
+pub trait ClientHandshakeComplete {
+    type KeyGen;
+    type ServerAuxData;
+    type Remainder;
+    fn keygen(&self) -> &Self::KeyGen;
+    fn extensions(&self) -> &Self::ServerAuxData;
+    fn remainder(&self) -> &Self::Remainder;
 }
 
 /// Trait for an object that handles incoming auxiliary data and
@@ -201,7 +206,7 @@ pub enum RelayHandshakeError {
 
     /// Error happened during cryptographic handshake
     #[error("")]
-    CryptoError(mlkem1024_x25519::EncodeError),
+    CryptoError(xwing::EncodeError),
 
     /// The client asked for a key we didn't have.
     #[error("Client asked for a key or ID that we don't have")]

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -85,16 +85,16 @@ pub trait ClientHandshake {
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
+    fn client2<T: AsRef<[u8]>>(state: &mut Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
 }
 
 pub trait ClientHandshakeComplete {
     type KeyGen;
     type ServerAuxData;
     type Remainder;
-    fn keygen(&self) -> &Self::KeyGen;
+    fn keygen(&self) -> Self::KeyGen;
     fn extensions(&self) -> &Self::ServerAuxData;
-    fn remainder(&self) -> &Self::Remainder;
+    fn remainder(&self) -> Self::Remainder;
 }
 
 /// Trait for an object that handles incoming auxiliary data and

--- a/crates/o5/src/common/xwing.rs
+++ b/crates/o5/src/common/xwing.rs
@@ -40,7 +40,7 @@ struct HybridKey {
 }
 
 #[derive(Clone, PartialEq)]
-pub(crate) struct PublicKey {
+pub struct PublicKey {
     x25519: x25519_dalek::PublicKey,
     mlkem: EncapsulationKey<ml_kem::MlKem1024>,
     pub_key: [u8; PUBKEY_LEN],

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -4,14 +4,14 @@ use tor_llcrypto::pk::ed25519::ED25519_ID_LEN;
 
 pub use crate::common::ntor_arti::SESSION_ID_LEN;
 use crate::{
-    common::{drbg, mlkem1024_x25519, x25519_elligator2::REPRESENTATIVE_LENGTH},
+    common::{drbg, x25519_elligator2::REPRESENTATIVE_LENGTH, xwing},
     framing,
     handshake::AUTHCODE_LENGTH,
 };
 
 use std::time::Duration;
 
-pub const PUBLIC_KEY_LEN: usize = mlkem1024_x25519::PUBKEY_LEN;
+pub const PUBLIC_KEY_LEN: usize = xwing::PUBKEY_LEN;
 
 //=========================[Framing/Msgs]=====================================//
 
@@ -76,4 +76,4 @@ pub const SEED_LENGTH: usize = drbg::SEED_LENGTH;
 pub const HEADER_LENGTH: usize = framing::FRAME_OVERHEAD + framing::MESSAGE_OVERHEAD;
 
 pub const NODE_ID_LENGTH: usize = ED25519_ID_LEN;
-pub const NODE_PUBKEY_LENGTH: usize = mlkem1024_x25519::PUBKEY_LEN;
+pub const NODE_PUBKEY_LENGTH: usize = xwing::PUBKEY_LEN;

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -108,7 +108,7 @@ pub struct ClientHandshakeMessage<'a> {
 }
 
 impl<'a> ClientHandshakeMessage<'a> {
-    pub fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
+    pub(crate) fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
         Self {
             hs_materials,
             client_session_pubkey,

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -108,7 +108,10 @@ pub struct ClientHandshakeMessage<'a> {
 }
 
 impl<'a> ClientHandshakeMessage<'a> {
-    pub(crate) fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
+    pub(crate) fn new(
+        client_session_pubkey: SessionPublicKey,
+        hs_materials: &'a CHSMaterials,
+    ) -> Self {
         Self {
             hs_materials,
             client_session_pubkey,

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -8,14 +8,17 @@ use crate::{
     Result,
 };
 
-use bytes::BufMut;
 use block_buffer::Eager;
-use digest::{core_api::{BlockSizeUser, CoreProxy, UpdateCore, FixedOutputCore, BufferKindUser}, HashMarker};
+use bytes::BufMut;
+use digest::{
+    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
+    HashMarker,
+};
 use hmac::{Hmac, Mac};
 use ptrs::trace;
-use typenum::{consts::U256, operator_aliases::Le, type_operators::IsLess, marker_traits::NonZero};
 use tor_cell::relaycell::extend::NtorV3Extension;
 use tor_llcrypto::d::Sha3_256;
+use typenum::{consts::U256, marker_traits::NonZero, operator_aliases::Le, type_operators::IsLess};
 
 // -----------------------------[ Server ]-----------------------------
 
@@ -125,11 +128,7 @@ impl<'a> ClientHandshakeMessage<'a> {
         self.epoch_hour.clone()
     }
 
-    pub fn marshall(
-        &mut self,
-        buf: &mut impl BufMut,
-        key: &[u8],
-    ) -> Result<()> {
+    pub fn marshall(&mut self, buf: &mut impl BufMut, key: &[u8]) -> Result<()> {
         trace!("serializing client handshake");
 
         let h = Hmac::<Sha3_256>::new_from_slice(key).unwrap();
@@ -140,7 +139,12 @@ impl<'a> ClientHandshakeMessage<'a> {
     pub fn marshall_inner<D>(&mut self, _buf: &mut impl BufMut, _h: Hmac<D>) -> Result<()>
     where
         D: CoreProxy,
-        D::Core: HashMarker + UpdateCore + FixedOutputCore + BufferKindUser<BufferKind = Eager> + Default + Clone,
+        D::Core: HashMarker
+            + UpdateCore
+            + FixedOutputCore
+            + BufferKindUser<BufferKind = Eager>
+            + Default
+            + Clone,
         <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
         Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
     {

--- a/crates/o5/src/handshake.rs
+++ b/crates/o5/src/handshake.rs
@@ -21,18 +21,18 @@ pub(crate) use keys::{Authcode, NtorV3KeyGenerator, AUTHCODE_LENGTH};
 pub use keys::{IdentityPublicKey, IdentitySecretKey, NtorV3KeyGen};
 
 /// Super trait to be used where we require a distinction between client and server roles.
-trait Role {
+pub trait Role {
     fn is_client() -> bool;
 }
 
-struct ClientRole {}
+pub struct ClientRole {}
 impl Role for ClientRole {
     fn is_client() -> bool {
         true
     }
 }
 
-struct ServerRole {}
+pub struct ServerRole {}
 impl Role for ServerRole {
     fn is_client() -> bool {
         false

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::{
         ct,
-        mlkem1024_x25519::SharedSecret,
-        ntor_arti::{ClientHandshake, ClientHandshakeMaterials},
+        ntor_arti::{ClientHandshake, ClientHandshakeComplete, ClientHandshakeMaterials},
+        xwing::SharedSecret,
     },
     constants::*,
     framing::handshake::ClientHandshakeMessage,
@@ -25,7 +25,6 @@ use tor_llcrypto::{
     pk::ed25519::Ed25519Identity,
 };
 use zeroize::Zeroizing;
-
 
 /// Client state for the o5 (ntor v3) handshake.
 ///
@@ -52,7 +51,7 @@ pub(crate) struct HandshakeState {
 }
 
 impl HandshakeState {
-    fn node_pubkey(&self) -> &mlkem1024_x25519::PublicKey {
+    fn node_pubkey(&self) -> &xwing::PublicKey {
         &self.materials.node_pubkey.pk
     }
 
@@ -102,11 +101,31 @@ impl ClientHandshakeMaterials for HandshakeMaterials {
 /// Client side of the ntor v3 handshake.
 pub(crate) struct NtorV3Client;
 
-impl ClientHandshake for NtorV3Client {
-    type StateType = HandshakeState;
+/// State resulting from successful client handshake.
+pub struct HsComplete {
+    keygen: NtorV3KeyGenerator,
+    extensions: Vec<NtorV3Extension>,
+    remainder: (),
+}
+impl ClientHandshakeComplete for HsComplete {
     type KeyGen = NtorV3KeyGenerator;
     type ServerAuxData = Vec<NtorV3Extension>;
+    type Remainder = ();
+    fn keygen(&self) -> &Self::KeyGen {
+        &self.keygen
+    }
+    fn extensions(&self) -> &Self::ServerAuxData {
+        &self.extensions
+    }
+    fn remainder(&self) -> &Self::Remainder {
+        &self.remainder
+    }
+}
+
+impl ClientHandshake for NtorV3Client {
+    type StateType = HandshakeState;
     type HandshakeMaterials = HandshakeMaterials;
+    type HsOutput = HsComplete;
 
     /// Generate a new client onionskin for a relay with a given onion key.
     /// If any `extensions` are provided, encode them into to the onionskin.
@@ -126,10 +145,7 @@ impl ClientHandshake for NtorV3Client {
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(
-        state: Self::StateType,
-        msg: T,
-    ) -> Result<(Vec<NtorV3Extension>, Self::KeyGen)> {
+    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<Self::HsOutput> {
         let (message, xofreader) =
             client_handshake_ntor_v3_part2(&state, msg.as_ref(), NTOR3_CIRC_VERIFICATION)?;
         let extensions = NtorV3Extension::decode(&message).map_err(|err| Error::CellDecodeErr {
@@ -138,7 +154,11 @@ impl ClientHandshake for NtorV3Client {
         })?;
         let keygen = NtorV3KeyGenerator::new::<ClientRole>(xofreader);
 
-        Ok((extensions, keygen))
+        Ok(HsComplete {
+            extensions,
+            keygen,
+            remainder: (),
+        })
     }
 }
 
@@ -163,50 +183,52 @@ pub(crate) fn client_handshake_ntor_v3_no_keygen(
     materials: HandshakeMaterials,
     verification: &[u8],
 ) -> EncodeResult<(HandshakeState, Vec<u8>)> {
-    let my_public = SessionPublicKey::from(&my_sk);
-    let client_msg = ClientHandshakeMessage::new(my_public.clone(), &materials);
+    todo!("client handshake part 1");
 
-    // --------
-    let node_pubkey = materials.node_pubkey();
-    // let bx = my_sk.diffie_hellman(&node_pubkey);
-    let mut rng = rand::thread_rng();
-    let (ct, bx) = my_sk.hpke(&mut rng, materials.node_pubkey.pk)?;
-    // .map_err(|e| Error::Crypto(e.to_string()));
+    // let my_public = SessionPublicKey::from(&my_sk);
+    // let client_msg = ClientHandshakeMessage::new(my_public.clone(), &materials);
 
-    let (enc_key, mut mac) = kdf_msgkdf(&bx, node_pubkey, &my_public, verification)?;
+    // // --------
+    // let node_pubkey = materials.node_pubkey();
+    // // let bx = my_sk.diffie_hellman(&node_pubkey);
+    // let mut rng = rand::thread_rng();
+    // let (ct, bx) = my_sk.hpke(&mut rng, materials.node_pubkey.pk)?;
+    // // .map_err(|e| Error::Crypto(e.to_string()));
 
-    // encrypted_msg = ENC(ENC_K1, CM)
-    // msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
-    let encrypted_msg = encrypt(&enc_key, client_msg);
-    let msg_mac: DigestVal = {
-        use digest::Digest;
-        mac.write(&encrypted_msg)?;
-        mac.take().finalize().into()
-    };
+    // let (enc_key, mut mac) = kdf_msgkdf(&bx, node_pubkey, &my_public, verification)?;
 
-    let mut message = Vec::new();
-    message.write(&node_pubkey.id)?;
-    message.write(&node_pubkey.pk.as_bytes())?;
-    message.write(&my_public.as_bytes())?;
-    message.write(&encrypted_msg)?;
-    message.write(&msg_mac)?;
-    // --------
+    // // encrypted_msg = ENC(ENC_K1, CM)
+    // // msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
+    // let encrypted_msg = encrypt(&enc_key, client_msg);
+    // let msg_mac: DigestVal = {
+    //     use digest::Digest;
+    //     mac.write(&encrypted_msg)?;
+    //     mac.take().finalize().into()
+    // };
 
-    let mut buf = BytesMut::with_capacity(MAX_HANDSHAKE_LENGTH);
-    let mut hmac_key = materials.node_pubkey.pk.as_bytes().to_vec();
-    hmac_key.append(&mut materials.node_pubkey.id.as_bytes().to_vec());
-    client_msg.marshall(&mut buf, &hmac_key[..]);
-    let message = buf.to_vec();
+    // let mut message = Vec::new();
+    // message.write(&node_pubkey.id)?;
+    // message.write(&node_pubkey.pk.as_bytes())?;
+    // message.write(&my_public.as_bytes())?;
+    // message.write(&encrypted_msg)?;
+    // message.write(&msg_mac)?;
+    // // --------
 
-    let state = HandshakeState {
-        materials,
-        my_sk,
-        shared_secret: bx,
-        msg_mac,
-        epoch_hr: client_msg.get_epoch_hr(),
-    };
+    // let mut buf = BytesMut::with_capacity(MAX_HANDSHAKE_LENGTH);
+    // let mut hmac_key = materials.node_pubkey.pk.as_bytes().to_vec();
+    // hmac_key.append(&mut materials.node_pubkey.id.as_bytes().to_vec());
+    // client_msg.marshall(&mut buf, &hmac_key[..]);
+    // let message = buf.to_vec();
 
-    Ok((state, message))
+    // let state = HandshakeState {
+    //     materials,
+    //     my_sk,
+    //     shared_secret: bx,
+    //     msg_mac,
+    //     epoch_hr: client_msg.get_epoch_hr(),
+    // };
+
+    // Ok((state, message))
 }
 
 /// Finalize the handshake on the client side.
@@ -221,72 +243,74 @@ pub(crate) fn client_handshake_ntor_v3_part2(
     relay_handshake: &[u8],
     verification: &[u8],
 ) -> Result<(Vec<u8>, NtorV3XofReader)> {
-    let mut reader = Reader::from_slice(relay_handshake);
-    let y_pk: SessionPublicKey = reader
-        .extract()
-        .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    let auth: DigestVal = reader
-        .extract()
-        .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    let encrypted_msg = reader.into_rest();
-    let my_public = SessionPublicKey::from(&state.my_sk);
+    todo!("client handshake part 2");
 
-    // TODO: Some of this code is duplicated from the server handshake code!  It
-    // would be better to factor it out.
-    let yx = state.my_sk.diffie_hellman(&y_pk);
-    let secret_input = {
-        let mut si = SecretBuf::new();
-        si.write(&yx)
-            .and_then(|_| si.write(&state.shared_secret.as_bytes()))
-            .and_then(|_| si.write(&state.node_id()))
-            .and_then(|_| si.write(&state.node_pubkey().as_bytes()))
-            .and_then(|_| si.write(&my_public.as_bytes()))
-            .and_then(|_| si.write(&y_pk.as_bytes()))
-            .and_then(|_| si.write(PROTOID))
-            .and_then(|_| si.write(&Encap(verification)))
-            .map_err(into_internal!("error encoding ntor3 secret_input"))?;
-        si
-    };
-    let ntor_key_seed = h_key_seed(&secret_input);
-    let verify = h_verify(&secret_input);
+    // let mut reader = Reader::from_slice(relay_handshake);
+    // let y_pk: SessionPublicKey = reader
+    //     .extract()
+    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
+    // let auth: DigestVal = reader
+    //     .extract()
+    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
+    // let encrypted_msg = reader.into_rest();
+    // let my_public = SessionPublicKey::from(&state.my_sk);
 
-    let computed_auth: DigestVal = {
-        use digest::Digest;
-        let mut auth = DigestWriter(Sha3_256::default());
-        auth.write(&T_AUTH)
-            .and_then(|_| auth.write(&verify))
-            .and_then(|_| auth.write(&state.node_id()))
-            .and_then(|_| auth.write(&state.node_pubkey().as_bytes()))
-            .and_then(|_| auth.write(&y_pk.as_bytes()))
-            .and_then(|_| auth.write(&my_public.as_bytes()))
-            .and_then(|_| auth.write(&state.msg_mac))
-            .and_then(|_| auth.write(&Encap(encrypted_msg)))
-            .and_then(|_| auth.write(PROTOID))
-            .and_then(|_| auth.write(&b"Server"[..]))
-            .map_err(into_internal!("error encoding ntor3 authentication input"))?;
-        auth.take().finalize().into()
-    };
+    // // TODO: Some of this code is duplicated from the server handshake code!  It
+    // // would be better to factor it out.
+    // let yx = state.my_sk.diffie_hellman(&y_pk);
+    // let secret_input = {
+    //     let mut si = SecretBuf::new();
+    //     si.write(&yx)
+    //         .and_then(|_| si.write(&state.shared_secret.as_bytes()))
+    //         .and_then(|_| si.write(&state.node_id()))
+    //         .and_then(|_| si.write(&state.node_pubkey().as_bytes()))
+    //         .and_then(|_| si.write(&my_public.as_bytes()))
+    //         .and_then(|_| si.write(&y_pk.as_bytes()))
+    //         .and_then(|_| si.write(PROTOID))
+    //         .and_then(|_| si.write(&Encap(verification)))
+    //         .map_err(into_internal!("error encoding ntor3 secret_input"))?;
+    //     si
+    // };
+    // let ntor_key_seed = h_key_seed(&secret_input);
+    // let verify = h_verify(&secret_input);
 
-    let okay = computed_auth.ct_eq(&auth)
-        & ct::bool_to_choice(yx.was_contributory())
-        & ct::bool_to_choice(state.shared_secret.was_contributory());
+    // let computed_auth: DigestVal = {
+    //     use digest::Digest;
+    //     let mut auth = DigestWriter(Sha3_256::default());
+    //     auth.write(&T_AUTH)
+    //         .and_then(|_| auth.write(&verify))
+    //         .and_then(|_| auth.write(&state.node_id()))
+    //         .and_then(|_| auth.write(&state.node_pubkey().as_bytes()))
+    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&my_public.as_bytes()))
+    //         .and_then(|_| auth.write(&state.msg_mac))
+    //         .and_then(|_| auth.write(&Encap(encrypted_msg)))
+    //         .and_then(|_| auth.write(PROTOID))
+    //         .and_then(|_| auth.write(&b"Server"[..]))
+    //         .map_err(into_internal!("error encoding ntor3 authentication input"))?;
+    //     auth.take().finalize().into()
+    // };
 
-    let (enc_key, keystream) = {
-        use digest::{ExtendableOutput, XofReader};
-        let mut xof = DigestWriter(Shake256::default());
-        xof.write(&T_FINAL)
-            .and_then(|_| xof.write(&ntor_key_seed))
-            .map_err(into_internal!("error encoding ntor3 xof input"))?;
-        let mut r = xof.take().finalize_xof();
-        let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-        r.read(&mut enc_key[..]);
-        (enc_key, r)
-    };
-    let server_reply = decrypt(&enc_key, encrypted_msg);
+    // let okay = computed_auth.ct_eq(&auth)
+    //     & ct::bool_to_choice(yx.was_contributory())
+    //     & ct::bool_to_choice(state.shared_secret.was_contributory());
 
-    if okay.into() {
-        Ok((server_reply, NtorV3XofReader::new(keystream)))
-    } else {
-        Err(Error::BadCircHandshakeAuth)
-    }
+    // let (enc_key, keystream) = {
+    //     use digest::{ExtendableOutput, XofReader};
+    //     let mut xof = DigestWriter(Shake256::default());
+    //     xof.write(&T_FINAL)
+    //         .and_then(|_| xof.write(&ntor_key_seed))
+    //         .map_err(into_internal!("error encoding ntor3 xof input"))?;
+    //     let mut r = xof.take().finalize_xof();
+    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
+    //     r.read(&mut enc_key[..]);
+    //     (enc_key, r)
+    // };
+    // let server_reply = decrypt(&enc_key, encrypted_msg);
+
+    // if okay.into() {
+    //     Ok((server_reply, NtorV3XofReader::new(keystream)))
+    // } else {
+    //     Err(Error::BadCircHandshakeAuth)
+    // }
 }

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -4,7 +4,7 @@ use crate::{
         ntor_arti::{
             ClientHandshake, ClientHandshakeComplete, ClientHandshakeMaterials, KeyGenerator,
         },
-        xwing::SharedSecret,
+        xwing::{DecapsulationKey, SharedSecret},
     },
     constants::*,
     framing::handshake::ClientHandshakeMessage,
@@ -53,8 +53,8 @@ pub(crate) struct HandshakeState {
 }
 
 impl HandshakeState {
-    fn node_pubkey(&self) -> &xwing::PublicKey {
-        &self.materials.node_pubkey.pk
+    fn node_pubkey(&self) -> &xwing::EncapsulationKey {
+        &self.materials.node_pubkey.ek
     }
 
     fn node_id(&self) -> Ed25519Identity {
@@ -174,8 +174,8 @@ pub(crate) fn client_handshake_ntor_v3<R: RngCore + CryptoRng>(
     materials: HandshakeMaterials,
     verification: &[u8],
 ) -> EncodeResult<(HandshakeState, Vec<u8>)> {
-    let my_sk = SessionSecretKey::random_from_rng(rng);
-    client_handshake_ntor_v3_no_keygen(my_sk, materials, verification)
+    let (dk_session, _ek_session) = xwing::generate_key_pair(rng);
+    client_handshake_ntor_v3_no_keygen(dk_session, materials, verification)
 }
 
 /// As `client_handshake_ntor_v3`, but don't generate an ephemeral DH

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -205,7 +205,7 @@ impl KeyGenerator for NtorV3KeyGenerator {
 impl NtorV3KeyGen for NtorV3KeyGenerator {}
 
 impl NtorV3KeyGenerator {
-    pub(crate) fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
+    pub fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
         // let okm = Self::kdf(&seed[..], KEY_MATERIAL_LENGTH * 2 + SESSION_ID_LEN)
         //     .expect("bug: failed to derive key material from seed");
 

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -171,6 +171,7 @@ impl Into<xwing::PublicKey> for &IdentitySecretKey {
 pub trait NtorV3KeyGen: KeyGenerator + SessionIdentifier + Into<O5Codec> {}
 
 /// Opaque wrapper type for NtorV3's hash reader.
+#[derive(Clone)]
 pub(crate) struct NtorV3XofReader(Shake256Reader);
 
 impl NtorV3XofReader {
@@ -249,9 +250,9 @@ impl KeyGenerator for NtorV3XofReader {
     }
 }
 
-impl From<NtorV3KeyGenerator> for O5Codec {
-    fn from(keygen: NtorV3KeyGenerator) -> Self {
-        keygen.codec
+impl<K: NtorV3KeyGen> From<K> for O5Codec {
+    fn from(value: K) -> Self {
+        value.into()
     }
 }
 

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -187,7 +187,7 @@ impl digest::XofReader for NtorV3XofReader {
 }
 
 /// A key generator returned from an ntor v3 handshake.
-pub(crate) struct NtorV3KeyGenerator {
+pub struct NtorV3KeyGenerator {
     /// The underlying `digest::XofReader`.
     reader: NtorV3XofReader,
     session_id: SessionID,

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -31,7 +31,7 @@ pub(crate) struct HandshakeMaterials {
 
 impl<'a> HandshakeMaterials {
     pub fn get_hmac<'b>(&self, identity_keys: &'b IdentitySecretKey) -> Hmac<Sha256> {
-        let mut key = identity_keys.pk.pk.as_bytes().to_vec();
+        let mut key = identity_keys.pk.ek.as_bytes().to_vec();
         key.append(&mut identity_keys.pk.id.as_bytes().to_vec());
         Hmac::<Sha256>::new_from_slice(&key[..]).unwrap()
     }
@@ -96,8 +96,8 @@ pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply>(
     keys: &IdentitySecretKey,
     verification: &[u8],
 ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    let secret_key_y = SessionSecretKey::random_from_rng(rng);
-    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &secret_key_y, message, keys, verification)
+    let (dk_session, _ek_session) = xwing::generate_key_pair(rng);
+    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &dk_session, message, keys, verification)
 }
 
 /// As `server_handshake_ntor_v3`, but take a secret key instead of an RNG.

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -109,117 +109,119 @@ pub(crate) fn server_handshake_ntor_v3_no_keygen<R: CryptoRng + RngCore, REPLY: 
     keys: &IdentitySecretKey,
     verification: &[u8],
 ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    // Decode the message.
-    let mut r = Reader::from_slice(message);
-    let id: Ed25519Identity = r.extract()?;
-    let requested_pk: IdentityPublicKey = r.extract()?;
-    let client_pk: SessionPublicKey = r.extract()?;
-    let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
-        r.take(msg_len)?
-    } else {
-        let deficit = (MAC_LEN - r.remaining())
-            .try_into()
-            .expect("miscalculated!");
-        return Err(Error::incomplete_error(deficit).into());
-    };
+    todo!("server handshake");
 
-    let msg_mac: MessageMac = r.extract()?;
-    r.should_be_exhausted()?;
+    // // Decode the message.
+    // let mut r = Reader::from_slice(message);
+    // let id: Ed25519Identity = r.extract()?;
+    // let requested_pk: IdentityPublicKey = r.extract()?;
+    // let client_pk: SessionPublicKey = r.extract()?;
+    // let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
+    //     r.take(msg_len)?
+    // } else {
+    //     let deficit = (MAC_LEN - r.remaining())
+    //         .try_into()
+    //         .expect("miscalculated!");
+    //     return Err(Error::incomplete_error(deficit).into());
+    // };
 
-    // See if we recognize the provided (id,requested_pk) pair.
-    let keypair = match keys.matches(id, requested_pk.pk).into() {
-        Some(k) => keys,
-        None => return Err(RelayHandshakeError::MissingKey),
-    };
+    // let msg_mac: MessageMac = r.extract()?;
+    // r.should_be_exhausted()?;
 
-    let xb = keypair
-        .hpke(rng, &client_pk)
-        .map_err(|e| Error::Crypto(e.into()))?;
-    let (enc_key, mut mac) = kdf_msgkdf(&xb, &keypair.pk, &client_pk, verification)
-        .map_err(into_internal!("Can't apply ntor3 kdf."))?;
-    // Verify the message we received.
-    let computed_mac: DigestVal = {
-        mac.write(client_msg)
-            .map_err(into_internal!("Can't compute MAC input."))?;
-        mac.take().finalize().into()
-    };
-    let y_pk = SessionPublicKey::from(secret_key_y);
-    let xy = secret_key_y.hpke(rng, &client_pk)?;
+    // // See if we recognize the provided (id,requested_pk) pair.
+    // let keypair = match keys.matches(id, requested_pk.pk).into() {
+    //     Some(k) => keys,
+    //     None => return Err(RelayHandshakeError::MissingKey),
+    // };
 
-    let mut okay = computed_mac.ct_eq(&msg_mac)
-        & ct::bool_to_choice(xy.was_contributory())
-        & ct::bool_to_choice(xb.was_contributory());
+    // let xb = keypair
+    //     .hpke(rng, &client_pk)
+    //     .map_err(|e| Error::Crypto(e.into()))?;
+    // let (enc_key, mut mac) = kdf_msgkdf(&xb, &keypair.pk, &client_pk, verification)
+    //     .map_err(into_internal!("Can't apply ntor3 kdf."))?;
+    // // Verify the message we received.
+    // let computed_mac: DigestVal = {
+    //     mac.write(client_msg)
+    //         .map_err(into_internal!("Can't compute MAC input."))?;
+    //     mac.take().finalize().into()
+    // };
+    // let y_pk = SessionPublicKey::from(secret_key_y);
+    // let xy = secret_key_y.hpke(rng, &client_pk)?;
 
-    let plaintext_msg = decrypt(&enc_key, client_msg);
+    // let mut okay = computed_mac.ct_eq(&msg_mac)
+    //     & ct::bool_to_choice(xy.was_contributory())
+    //     & ct::bool_to_choice(xb.was_contributory());
 
-    // Handle the message and decide how to reply.
-    let reply = reply_fn.reply(&plaintext_msg);
+    // let plaintext_msg = decrypt(&enc_key, client_msg);
 
-    // It's not exactly constant time to use is_some() and
-    // unwrap_or_else() here, but that should be somewhat
-    // hidden by the rest of the computation.
-    okay &= ct::bool_to_choice(reply.is_some());
-    let reply = reply.unwrap_or_default();
+    // // Handle the message and decide how to reply.
+    // let reply = reply_fn.reply(&plaintext_msg);
 
-    // If we reach this point, we are actually replying, or pretending
-    // that we're going to reply.
+    // // It's not exactly constant time to use is_some() and
+    // // unwrap_or_else() here, but that should be somewhat
+    // // hidden by the rest of the computation.
+    // okay &= ct::bool_to_choice(reply.is_some());
+    // let reply = reply.unwrap_or_default();
 
-    let secret_input = {
-        let mut si = SecretBuf::new();
-        si.write(&xy.as_bytes())
-            .and_then(|_| si.write(&xb.as_bytes()))
-            .and_then(|_| si.write(&keypair.pk.id))
-            .and_then(|_| si.write(&keypair.pk.pk.as_bytes()))
-            .and_then(|_| si.write(&client_pk.as_bytes()))
-            .and_then(|_| si.write(&y_pk.as_bytes()))
-            .and_then(|_| si.write(PROTOID))
-            .and_then(|_| si.write(&Encap(verification)))
-            .map_err(into_internal!("can't derive ntor3 secret_input"))?;
-        si
-    };
-    let ntor_key_seed = h_key_seed(&secret_input);
-    let verify = h_verify(&secret_input);
+    // // If we reach this point, we are actually replying, or pretending
+    // // that we're going to reply.
 
-    let (enc_key, keystream) = {
-        let mut xof = DigestWriter(Shake256::default());
-        xof.write(&T_FINAL)
-            .and_then(|_| xof.write(&ntor_key_seed))
-            .map_err(into_internal!("can't generate ntor3 xof."))?;
-        let mut r = xof.take().finalize_xof();
-        let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-        r.read(&mut enc_key[..]);
-        (enc_key, r)
-    };
-    let encrypted_reply = encrypt(&enc_key, &reply);
-    let auth: DigestVal = {
-        let mut auth = DigestWriter(Sha3_256::default());
-        auth.write(&T_AUTH)
-            .and_then(|_| auth.write(&verify))
-            .and_then(|_| auth.write(&keypair.pk.id))
-            .and_then(|_| auth.write(&keypair.pk.pk.as_bytes()))
-            .and_then(|_| auth.write(&y_pk.as_bytes()))
-            .and_then(|_| auth.write(&client_pk.as_bytes()))
-            .and_then(|_| auth.write(&msg_mac))
-            .and_then(|_| auth.write(&Encap(&encrypted_reply)))
-            .and_then(|_| auth.write(PROTOID))
-            .and_then(|_| auth.write(&b"Server"[..]))
-            .map_err(into_internal!("can't derive ntor3 authentication"))?;
-        auth.take().finalize().into()
-    };
+    // let secret_input = {
+    //     let mut si = SecretBuf::new();
+    //     si.write(&xy.as_bytes())
+    //         .and_then(|_| si.write(&xb.as_bytes()))
+    //         .and_then(|_| si.write(&keypair.pk.id))
+    //         .and_then(|_| si.write(&keypair.pk.pk.as_bytes()))
+    //         .and_then(|_| si.write(&client_pk.as_bytes()))
+    //         .and_then(|_| si.write(&y_pk.as_bytes()))
+    //         .and_then(|_| si.write(PROTOID))
+    //         .and_then(|_| si.write(&Encap(verification)))
+    //         .map_err(into_internal!("can't derive ntor3 secret_input"))?;
+    //     si
+    // };
+    // let ntor_key_seed = h_key_seed(&secret_input);
+    // let verify = h_verify(&secret_input);
 
-    let reply = {
-        let mut reply = Vec::new();
-        reply
-            .write(&y_pk.as_bytes())
-            .and_then(|_| reply.write(&auth))
-            .and_then(|_| reply.write(&encrypted_reply))
-            .map_err(into_internal!("can't encode ntor3 reply."))?;
-        reply
-    };
+    // let (enc_key, keystream) = {
+    //     let mut xof = DigestWriter(Shake256::default());
+    //     xof.write(&T_FINAL)
+    //         .and_then(|_| xof.write(&ntor_key_seed))
+    //         .map_err(into_internal!("can't generate ntor3 xof."))?;
+    //     let mut r = xof.take().finalize_xof();
+    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
+    //     r.read(&mut enc_key[..]);
+    //     (enc_key, r)
+    // };
+    // let encrypted_reply = encrypt(&enc_key, &reply);
+    // let auth: DigestVal = {
+    //     let mut auth = DigestWriter(Sha3_256::default());
+    //     auth.write(&T_AUTH)
+    //         .and_then(|_| auth.write(&verify))
+    //         .and_then(|_| auth.write(&keypair.pk.id))
+    //         .and_then(|_| auth.write(&keypair.pk.pk.as_bytes()))
+    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&client_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&msg_mac))
+    //         .and_then(|_| auth.write(&Encap(&encrypted_reply)))
+    //         .and_then(|_| auth.write(PROTOID))
+    //         .and_then(|_| auth.write(&b"Server"[..]))
+    //         .map_err(into_internal!("can't derive ntor3 authentication"))?;
+    //     auth.take().finalize().into()
+    // };
 
-    if okay.into() {
-        Ok((reply, NtorV3XofReader::new(keystream)))
-    } else {
-        Err(RelayHandshakeError::BadClientHandshake)
-    }
+    // let reply = {
+    //     let mut reply = Vec::new();
+    //     reply
+    //         .write(&y_pk.as_bytes())
+    //         .and_then(|_| reply.write(&auth))
+    //         .and_then(|_| reply.write(&encrypted_reply))
+    //         .map_err(into_internal!("can't encode ntor3 reply."))?;
+    //     reply
+    // };
+
+    // if okay.into() {
+    //     Ok((reply, NtorV3XofReader::new(keystream)))
+    // } else {
+    //     Err(RelayHandshakeError::BadClientHandshake)
+    // }
 }

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,4 +1,6 @@
 #![doc = include_str!("../README.md")]
+
+// #![warn(missing_docs)]
 #![allow(unused)]
 
 pub mod client;

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-
 // #![warn(missing_docs)]
 #![allow(unused)]
 

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(unused)]
 
 pub mod client;
 pub mod common;

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -74,7 +74,7 @@ where
 
         trace!(
             "node_pubkey: {}, node_id: {}",
-            hex::encode(self.identity_keys.pk.pk.as_bytes()),
+            hex::encode(self.identity_keys.pk.ek.as_bytes()),
             hex::encode(self.identity_keys.pk.id.as_bytes()),
         );
         Ok(self)

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -57,7 +57,7 @@ where
     type Error = Error;
     type Transport = Transport<T>;
 
-    fn build(&self) -> Self::ServerPT {
+    fn build(self) -> Self::ServerPT {
         crate::ServerBuilder::build(self)
     }
 
@@ -223,6 +223,10 @@ where
 
     fn method_name() -> String {
         TRANSPORT_NAME.into()
+    }
+
+    fn get_client_params(&self) -> String {
+        self.client_params().as_opts()
     }
 }
 

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -1,10 +1,14 @@
-use crate::{constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error, TRANSPORT_NAME};
+use crate::{
+    common::xwing, constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error,
+    TRANSPORT_NAME,
+};
 use ptrs::{args::Args, FutureResult as F};
 
 use std::{
     marker::PhantomData,
     net::{SocketAddrV4, SocketAddrV6},
     pin::Pin,
+    str::FromStr,
     time::Duration,
 };
 
@@ -148,13 +152,8 @@ where
             }
         };
 
-        self.with_node_pubkey(server_materials.pk.to_bytes())
-            .with_node_id(server_materials.id.into());
-        trace!(
-            "node_pubkey: {}, node_id: {}",
-            hex::encode(self.station_pubkey),
-            hex::encode(self.station_id),
-        );
+        self.with_node(server_materials);
+        trace!("node details: {:?}", &self.node_details,);
 
         Ok(self)
     }

--- a/crates/o5/src/server.rs
+++ b/crates/o5/src/server.rs
@@ -285,10 +285,7 @@ impl Server {
 
     pub fn client_params(&self) -> ClientBuilder {
         ClientBuilder {
-            // these unwraps should be safe as we are sure of the size of the source
-            station_pubkey: self.identity_keys.pk.pk.as_bytes().try_into().unwrap(),
-            station_id: self.identity_keys.pk.id.as_bytes().try_into().unwrap(),
-
+            node_details: self.identity_keys.pk.clone(),
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         }

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -2,7 +2,7 @@
 //!
 /// Session state management as a way to organize session establishment and
 /// steady state transfer.
-use crate::common::{drbg, mlkem1024_x25519};
+use crate::common::{drbg, xwing};
 
 use tor_bytes::Readable;
 
@@ -13,18 +13,16 @@ mod server;
 pub(crate) use server::ServerSession;
 
 /// Ephermeral single use session secret key type
-pub type SessionSecretKey = mlkem1024_x25519::StaticSecret;
+pub type SessionSecretKey = xwing::StaticSecret;
 
 /// Public key type associated with SessionSecretKey.
-pub type SessionPublicKey = mlkem1024_x25519::PublicKey;
-
+pub type SessionPublicKey = xwing::PublicKey;
 
 impl Readable for SessionPublicKey {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {
         todo!("SessionPublicKey Reader needs implemented");
     }
 }
-
 
 /// Initial state for a Session, created with any params.
 pub(crate) struct Initialized;

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -13,10 +13,10 @@ mod server;
 pub(crate) use server::ServerSession;
 
 /// Ephermeral single use session secret key type
-pub type SessionSecretKey = xwing::StaticSecret;
+pub type SessionSecretKey = xwing::DecapsulationKey;
 
 /// Public key type associated with SessionSecretKey.
-pub type SessionPublicKey = xwing::PublicKey;
+pub type SessionPublicKey = xwing::EncapsulationKey;
 
 impl Readable for SessionPublicKey {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -275,7 +275,7 @@ impl<S: ClientSessionState> std::fmt::Debug for ClientSession<S> {
             f,
             "[ id:{}, ident_pk:{}, epoch_hr:{} ]",
             hex::encode(self.node_pubkey.id.as_bytes()),
-            hex::encode(self.node_pubkey.pk.as_bytes()),
+            hex::encode(self.node_pubkey.ek.as_bytes()),
             self.epoch_hour,
         )
     }

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -1,11 +1,17 @@
 use crate::{
     common::{
         discard, drbg,
-        ntor_arti::{ClientHandshake, RelayHandshakeError, SessionID, SessionIdentifier},
+        ntor_arti::{
+            ClientHandshake, ClientHandshakeComplete, RelayHandshakeError, SessionID,
+            SessionIdentifier,
+        },
     },
     constants::*,
     framing,
-    handshake::{CHSMaterials, IdentityPublicKey, NtorV3Client, NtorV3KeyGen},
+    handshake::{
+        CHSMaterials, ClientHsComplete, IdentityPublicKey, NtorV3Client, NtorV3KeyGen,
+        NtorV3KeyGenerator,
+    },
     proto::{O5Stream, ObfuscatedStream},
     sessions::{Established, Fault, Initialized, Session},
     Error, Result,
@@ -13,7 +19,7 @@ use crate::{
 
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use ptrs::{debug, info};
 use rand_core::RngCore;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -142,8 +148,9 @@ impl ClientSession<Initialized> {
 
         // default deadline
         let d_def = Instant::now() + CLIENT_HANDSHAKE_TIMEOUT;
-        let handshake_fut = Self::complete_handshake(&mut stream, materials, deadline);
-        let (mut remainder, mut keygen) =
+        let handshake_fut =
+            Self::complete_handshake::<T, ClientHsComplete>(stream, materials, deadline);
+        let (mut hs_complete, mut stream) =
             match tokio::time::timeout_at(deadline.unwrap_or(d_def), handshake_fut).await {
                 Ok(result) => match result {
                     Ok(handshake) => handshake,
@@ -166,10 +173,16 @@ impl ClientSession<Initialized> {
             };
 
         // post-handshake state updates
+        let mut keygen: NtorV3KeyGenerator = hs_complete.keygen();
         session.set_session_id(keygen.session_id());
-        let mut codec: framing::O5Codec = keygen.into();
+        let mut codec = framing::O5Codec::from(keygen);
 
-        let res = codec.decode(&mut remainder);
+        // // TODO: handle server response extensions here
+        // for ext in hs_complete.extensions() {
+        //      // do something
+        // }
+
+        let res = codec.decode(&mut hs_complete.remainder());
         if let Ok(Some(framing::Messages::PrngSeed(seed))) = res {
             // try to parse the remainder of the server hello packet as a
             // PrngSeed since it should be there.
@@ -189,23 +202,26 @@ impl ClientSession<Initialized> {
         Ok(O5Stream::from_o4(o4))
     }
 
-    async fn complete_handshake<T>(
+    async fn complete_handshake<T, O>(
         mut stream: T,
         materials: CHSMaterials,
         deadline: Option<Instant>,
-    ) -> Result<(BytesMut, impl NtorV3KeyGen<ID = SessionID>)>
+    ) -> Result<(
+        impl ClientHandshakeComplete<Remainder = BytesMut, KeyGen = NtorV3KeyGenerator>,
+        T,
+    )>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {
         // let session_id = materials.session_id;
-        let (state, chs_message) = NtorV3Client::client1(materials)?;
+        let (mut state, chs_message) = NtorV3Client::client1(materials)?;
         // let mut file = tokio::fs::File::create("message.hex").await?;
         // file.write_all(&chs_message).await?;
         stream.write_all(&chs_message).await?;
 
         debug!(
             "{} handshake sent {}B, waiting for sever response",
-            materials.session_id,
+            state.materials.session_id,
             chs_message.len()
         );
 
@@ -220,18 +236,18 @@ impl ClientSession<Initialized> {
             }
             debug!(
                 "{} read {n}/{}B of server handshake",
-                materials.session_id,
+                state.materials.session_id,
                 buf.len()
             );
 
-            match NtorV3Client::client2(state, &buf[..n]) {
-                Ok(r) => return Ok(r),
+            match NtorV3Client::client2(&mut state, &buf[..n]) {
+                Ok(r) => return Ok((r, stream)),
                 Err(Error::HandshakeErr(RelayHandshakeError::EAgain)) => continue,
                 Err(e) => {
                     // if a deadline was set and has not passed already, discard
                     // from the stream until the deadline, then close.
                     if deadline.is_some_and(|d| d > Instant::now()) {
-                        debug!("{} discarding due to: {e}", materials.session_id);
+                        debug!("{} discarding due to: {e}", state.materials.session_id);
                         discard(&mut stream, deadline.unwrap() - Instant::now()).await?;
                     }
                     stream.shutdown().await?;

--- a/crates/o5/src/test_utils/mod.rs
+++ b/crates/o5/src/test_utils/mod.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 mod fake_prng;
+pub(crate) mod test_keys;
 pub mod tests;
 pub(crate) use fake_prng::*;
 

--- a/crates/o5/src/test_utils/test_keys.rs
+++ b/crates/o5/src/test_utils/test_keys.rs
@@ -1,0 +1,62 @@
+//! # Keys used for testing
+//!
+//! The hex representations of X-Wing keys are rather large. This module exists to house
+//! those representations so they don't muddy up the whole crate.
+//!
+//! ## Naming Conventions:
+//!
+//! id: Node ID
+//! b: Node identity secret key
+//! B: Node identity public key
+//!
+//! x: Client session secret Key
+//! X: Client session public Key
+//!
+//! y: Server session secret Key
+//! Y: Server session public Key
+//!
+//! within the X-Wing Keys X indicates an X25519 element, and M indicates an ML-KEM element
+//!
+//! xX: client session secret key x25519 element
+//! xM: client session secret key ML-KEM element
+//!
+//!
+//! The shared secrets used in a handshake are
+//!
+//! xB: client session secret key KEM with node identity public key
+//! Xb: server identity secret key KEM with client session public key
+//!
+//! xB == Xb == xX*BX + xM*BM = XX*bX + XM*bM
+//!
+//! Xy: server session secret key KEM with client session public key
+//! xY: client session secret key KEM with server session public key
+//!
+//! xY == Xy == xX*YX + xM*YM = XX*yX + XM*yM
+
+#[allow(non_snake_case)]
+pub struct HexKeys {
+    pub id: &'static str,
+    pub b: &'static str,
+    pub x: &'static str,
+    pub y: &'static str,
+
+    pub xB: &'static str,
+    pub xY: &'static str,
+
+    // Ciphertext of x encapsulated using B encoded using Elligator2 and Kemeleon
+    pub xB_C_EK: &'static str,
+
+    // Ciphertext of y encapsulated using X encoded using elligator2 and Kemeleon.
+    pub Xy_C_EK: &'static str,
+}
+
+pub const KEYS: [HexKeys; 1] = [HexKeys {
+    id: "aaaaaaaaaaaaaaaaaaaaaaaa9fad2af287ef942632833d21f946c6260c33fae6",
+    b: "4051daa5921cfa2a1c27b08451324919538e79e788a81b38cbed097a5dff454a",
+    x: "b825a3719147bcbe5fb1d0b0fcb9c09e51948048e2e3283d2ab7b45b5ef38b49",
+    y: "4865a5b7689dafd978f529291c7171bc159be076b92186405d13220b80e2a053",
+    xB: "",
+    xY: "",
+    xB_C_EK: "",
+    Xy_C_EK: "",
+}];

--- a/crates/obfs4/src/pt.rs
+++ b/crates/obfs4/src/pt.rs
@@ -59,7 +59,7 @@ where
     type Error = Error;
     type Transport = Transport<T>;
 
-    fn build(&self) -> Self::ServerPT {
+    fn build(self) -> Self::ServerPT {
         crate::ServerBuilder::build(self)
     }
 
@@ -245,6 +245,10 @@ where
 
     fn method_name() -> String {
         OBFS4_NAME.into()
+    }
+
+    fn get_client_params(&self) -> String {
+        self.client_params().as_opts()
     }
 }
 

--- a/crates/obfs4/src/server.rs
+++ b/crates/obfs4/src/server.rs
@@ -103,7 +103,7 @@ impl<T> ServerBuilder<T> {
         params.encode_smethod_args()
     }
 
-    pub fn build(&self) -> Server {
+    pub fn build(self) -> Server {
         Server(Arc::new(ServerInner {
             identity_keys: self.identity_keys.clone(),
             iat_mode: self.iat_mode,

--- a/crates/ptrs/src/lib.rs
+++ b/crates/ptrs/src/lib.rs
@@ -127,6 +127,13 @@ where
 
     /// Returns a string identifier for this transport
     fn method_name() -> String;
+
+    /// Returns a string or parameters that can be used by a ['ClientBuilder']
+    /// in the `options(...)` function to properly establish a connection with
+    /// this server based on the configuration of the server when this method
+    /// is called.
+    fn get_client_params(&self) -> String;
+
 }
 
 /// Server Transport builder interface
@@ -145,7 +152,7 @@ where
     ///
     /// **Errors**
     /// If a required field has not been initialized.
-    fn build(&self) -> Self::ServerPT;
+    fn build(self) -> Self::ServerPT;
 
     /// Pluggable transport attempts to parse and validate options from a string,
     /// typically using ['parse_smethod_args'].

--- a/crates/ptrs/src/lib.rs
+++ b/crates/ptrs/src/lib.rs
@@ -133,7 +133,6 @@ where
     /// this server based on the configuration of the server when this method
     /// is called.
     fn get_client_params(&self) -> String;
-
 }
 
 /// Server Transport builder interface

--- a/doc/pq-obfs-with-extra-data.md
+++ b/doc/pq-obfs-with-extra-data.md
@@ -1,0 +1,445 @@
+
+# TODO: THIS IS FOR LAYOUT AND HAS NOT BEEN UPDATED
+
+changes still to come
+
+```
+Filename: 332-ntor-v3-with-extra-data.md
+Title: Ntor protocol with extra data, version 3.
+Author: Nick Mathewson
+Created: 12 July 2021
+Status: Closed
+```
+
+# Overview
+
+The ntor handshake is our current protocol for circuit
+establishment.
+
+So far we have two variants of the ntor handshake in use: the "ntor
+v1" that we use for everyday circuit extension (see `tor-spec.txt`)
+and the "hs-ntor" that we use for v3 onion service handshake (see
+`rend-spec-v3.txt`).  This document defines a third version of ntor,
+adapting the improvements from hs-ntor for use in regular circuit
+establishment.
+
+These improvements include:
+
+ * Support for sending additional encrypted and authenticated
+   protocol-setup handshake data as part of the ntor handshake.  (The
+   information sent from the client to the relay does not receive
+   forward secrecy.)
+
+ * Support for using an external shared secret that both parties must
+   know in order to complete the handshake.  (In the HS handshake, this
+   is the subcredential.  We don't use it for circuit extension, but in
+   theory we could.)
+
+ * Providing a single specification that can, in the future, be used
+   both for circuit extension _and_ HS introduction.
+
+# The improved protocol: an abstract view
+
+Given a client "C" that wants to construct a circuit to a
+relay "S":
+
+The client knows:
+  * B: a public "onion key" for S
+  * ID: an identity for S, represented as a fixed-length
+    byte string.
+  * CM: a message that it wants to send to S as part of the
+    handshake.
+  * An optional "verification" string.
+
+The relay knows:
+  * A set of \[(b,B)...\] "onion key" keypairs.  One of them is
+    "current", the others are outdated, but still valid.
+  * ID: Its own identity.
+  * A function for computing a server message SM, based on a given
+    client message.
+  * An optional "verification" string. This must match the "verification"
+    string from the client.
+
+Both parties have a strong source of randomness.
+
+Given this information, the client computes a "client handshake"
+and sends it to the relay.
+
+The relay then uses its information plus the client handshake to see
+if the incoming message is valid; if it is, then it computes a
+"server handshake" to send in reply.
+
+The client processes the server handshake, and either succeeds or fails.
+
+At this point, the client and the relay both have access to:
+  * CM (the message the client sent)
+  * SM (the message the relay sent)
+  * KS (a shared byte stream of arbitrary length, used to compute
+    keys to be used elsewhere in the protocol).
+
+Additionally, the client knows that CM was sent _only_ to the relay
+whose public onion key is B, and that KS is shared _only_ with that
+relay.
+
+The relay does not know which client participated in the handshake,
+but it does know that CM came from the same client that generated
+the key X, and that SM and KS were shared _only_ with that client.
+
+Both parties know that CM, SM, and KS were shared correctly, or not
+at all.
+
+Both parties know that they used the same verification string; if
+they did not, they do not learn what the verification string was.
+(This feature is required for HS handshakes.)
+
+# The handshake in detail
+
+## Notation
+
+We use the following notation:
+
+  * `|` -- concatenation
+  * `"..."` -- a byte string, with no terminating NUL.
+  * `ENCAP(s)` -- an encapsulation function.  We define this
+     as `htonll(len(s)) | s`.  (Note that `len(ENCAP(s)) = len(s) + 8`).
+  * `PARTITION(s, n1, n2, n3, ...)` -- a function that partitions a
+     bytestring `s` into chunks of length `n1`, `n2`, `n3`, and so
+     on. Extra data is put into a final chunk.  If `s` is not long
+     enough, the function fails.
+
+We require the following crypto operations:
+
+  * `KDF(s,t)` -- a tweakable key derivation function, returning a
+     keystream of arbitrary length.
+  * `H(s,t)` -- a tweakable hash function of output length
+     `DIGEST_LEN`.
+  * `MAC(k, msg, t)` -- a tweakable message-authentication-code function,
+     with key length `MAC_KEY_LEN` and output length `MAC_LEN`.
+  * `EXP(pk,sk)` -- our Diffie Hellman group operation, taking a
+     public key of length `PUB_KEY_LEN`.
+  * `KEYGEN()` -- our Diffie-Hellman keypair generation algorithm,
+    returning a (secret-key,public-key) pair.
+  * `ENC(k, m)` -- a stream cipher with key of length `ENC_KEY_LEN`.
+    `DEC(k, m)` is its inverse.
+
+Parameters:
+
+  * `PROTOID` -- a short protocol identifier
+  * `t_*` -- a set of "tweak" strings, used to derive distinct
+    hashes from a single hash function.
+  * `ID_LEN` -- the length of an identity key that uniquely identifies
+    a relay.
+
+Given our cryptographic operations and a set of tweak strings, we
+define:
+
+```
+H_foo(s) = H(s, t_foo)
+MAC_foo(k, msg) = MAC(k, msg, t_foo)
+KDF_foo(s) = KDF(s, t_foo)
+```
+
+See Appendix A.1 below for a set of instantiations for these operations
+and constants.
+
+## Client operation, phase 1
+
+The client knows:
+    B, ID -- the onion key and ID of the relay it wants to use.
+    CM -- the message that it wants to send as part of its
+           handshake.
+    VER -- a verification string.
+
+First, the client generates a single-use keypair:
+
+    x,X = KEYGEN()
+
+and computes:
+
+    Bx = EXP(B,x)
+    secret_input_phase1 = Bx | ID | X | B | PROTOID | ENCAP(VER)
+    phase1_keys = KDF_msgkdf(secret_input_phase1)
+    (ENC_K1, MAC_K1) = PARTITION(phase1_keys, ENC_KEY_LEN, MAC_KEY_LEN)
+
+    encrypted_msg = ENC(ENC_K1, CM)
+    msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
+
+and sends:
+
+    NODEID      ID               [ID_LEN bytes]
+    KEYID       B                [PUB_KEY_LEN bytes]
+    CLIENT_PK   X                [PUB_KEY_LEN bytes]
+    MSG         encrypted_msg    [len(CM) bytes]
+    MAC         msg_mac          [last MAC_LEN bytes of message]
+
+The client remembers x, X, B, ID, Bx, and msg_mac.
+
+## Server operation
+
+The relay checks whether NODEID is as expected, and looks up
+the (b,B) keypair corresponding to KEYID.  If the keypair is
+missing or the NODEID is wrong, the handshake fails.
+
+Now the relay uses `X=CLIENT_PK` to compute:
+
+    Xb = EXP(X,b)
+    secret_input_phase1 = Xb | ID | X | B | PROTOID | ENCAP(VER)
+    phase1_keys = KDF_msgkdf(secret_input_phase1)
+    (ENC_K1, MAC_K1) = PARTITION(phase1_keys, ENC_KEY_LEN, MAC_KEY_LEN)
+
+    expected_mac = MAC_msgmac(MAC_K1, ID | B | X | MSG)
+
+If `expected_mac` is not `MAC`, the handshake fails.  Otherwise
+the relay computes `CM` as:
+
+    CM = DEC(MSG, ENC_K1)
+
+The relay then checks whether `CM` is well-formed, and in response
+composes `SM`, the reply that it wants to send as part of the
+handshake. It then generates a new ephemeral keypair:
+
+    y,Y = KEYGEN()
+
+and computes the rest of the handshake:
+
+    Xy = EXP(X,y)
+    secret_input = Xy | Xb | ID | B | X | Y | PROTOID | ENCAP(VER)
+    ntor_key_seed = H_key_seed(secret_input)
+    verify = H_verify(secret_input)
+
+    RAW_KEYSTREAM = KDF_final(ntor_key_seed)
+    (ENC_KEY, KEYSTREAM) = PARTITION(RAW_KEYSTREAM, ENC_KEY_LKEN, ...)
+
+    encrypted_msg = ENC(ENC_KEY, SM)
+
+    auth_input = verify | ID | B | Y | X | MAC | ENCAP(encrypted_msg) |
+        PROTOID | "Server"
+    AUTH = H_auth(auth_input)
+
+The relay then sends:
+
+    Y          Y              [PUB_KEY_LEN bytes]
+    AUTH       AUTH           [DIGEST_LEN bytes]
+    MSG        encrypted_msg  [len(SM) bytes, up to end of the message]
+
+The relay uses KEYSTREAM to generate the shared secrets for the
+newly created circuit.
+
+## Client operation, phase 2
+
+The client computes:
+
+    Yx = EXP(Y, x)
+    secret_input = Yx | Bx | ID | B | X | Y | PROTOID | ENCAP(VER)
+    ntor_key_seed = H_key_seed(secret_input)
+    verify = H_verify(secret_input)
+
+    auth_input = verify | ID | B | Y | X | MAC | ENCAP(MSG) |
+        PROTOID | "Server"
+    AUTH_expected = H_auth(auth_input)
+
+If AUTH_expected is equal to AUTH, then the handshake has
+succeeded.  The client can then calculate:
+
+    RAW_KEYSTREAM = KDF_final(ntor_key_seed)
+    (ENC_KEY, KEYSTREAM) = PARTITION(RAW_KEYSTREAM, ENC_KEY_LKEN, ...)
+
+    SM = DEC(ENC_KEY, MSG)
+
+SM is the message from the relay, and the client uses KEYSTREAM to
+generate the shared secrets for the newly created circuit.
+
+# Security notes
+
+Whenever comparing bytestrings, implementations SHOULD use
+constant-time comparison function to avoid side-channel attacks.
+
+To avoid small-subgroup attacks against the Diffie-Hellman function,
+implementations SHOULD either:
+
+   * Make sure that all incoming group members are in fact in the DH
+     group.
+   * Validate all outputs from the EXP function to make sure that
+     they are not degenerate.
+
+
+# Notes on usage
+
+We don't specify what should actually be done with the resulting
+keystreams; that depends on the usage for which this handshake is
+employed.  Typically, they'll be divided up into a series of tags
+and symmetric keys.
+
+The keystreams generated here are (conceptually) unlimited.  In
+practice, the usage will determine the amount of key material
+actually needed: that's the amount that clients and relays will
+actually generate.
+
+The PROTOID parameter should be changed not only if the
+cryptographic operations change here, but also if the usage changes
+at all, or if the meaning of any parameters changes.  (For example,
+if the encoding of CM and SM changed, or if ID were a different
+length or represented a different type of key, then we should start
+using a new PROTOID.)
+
+
+# A.1 Instantiation
+
+Here are a set of functions based on SHA3, SHAKE-256, Curve25519, and
+AES256:
+
+```
+H(s, t) = SHA3_256(ENCAP(t) | s)
+MAC(k, msg, t) = SHA3_256(ENCAP(t) | ENCAP(k) | s)
+KDF(s, t) = SHAKE_256(ENCAP(t) | s)
+ENC(k, m) = AES_256_CTR(k, m)
+
+EXP(pk,sk), KEYGEN: defined as in curve25519
+
+DIGEST_LEN = MAC_LEN = MAC_KEY_LEN = ENC_KEY_LEN = PUB_KEY_LEN = 32
+
+ID_LEN = 32  (representing an ed25519 identity key)
+```
+
+Notes on selected operations: SHA3 can be pretty slow, and AES256 is
+likely overkill.  I'm choosing them anyway because they are what we
+use in hs-ntor, and in my preliminary experiments they don't account
+for even 1% of the time spent on this handshake.
+
+```
+t_msgkdf = PROTOID | ":kdf_phase1"
+t_msgmac = PROTOID | ":msg_mac"
+t_key_seed = PROTOID | ":key_seed"
+t_verify = PROTOID | ":verify"
+t_final = PROTOID | ":kdf_final"
+t_auth = PROTOID | ":auth_final"
+```
+
+# A.2 Encoding for use with Tor circuit extension
+
+Here we give a concrete instantiation of ntor-v3 for use with
+circuit extension in Tor, and the parameters in A.1 above.
+
+If in use, this is a new CREATE2 type.  Clients should not use it
+unless the relay advertises support by including an appropriate
+version of the `Relay=X` subprotocol in its protocols list.
+
+When the encoding and methods of this section, along with the
+instantiations from the previous section, are in use, we specify:
+
+    PROTOID = "ntor3-curve25519-sha3_256-1"
+
+The key material is extracted as follows, unless modified by the
+handshake (see below).  See tor-spec.txt for more info on the
+specific values:
+
+    Df    Digest authentication, forwards  [20 bytes]
+    Db    Digest authentication, backwards [20 bytes]
+    Kf    Encryption key, forwards         [16 bytes]
+    Kb    Encryption key, backwards        [16 bytes]
+    KH    Onion service nonce              [20 bytes]
+
+We use the following meta-encoding for the contents of client and
+server messages.
+
+    [Any number of times]:
+    EXTENSION
+       EXT_FIELD_TYPE     [one byte]
+       EXT_FIELD_LEN      [one byte]
+       EXT_FIELD          [EXT_FIELD_LEN bytes]
+
+(`EXT_FIELD_LEN` may be zero, in which case EXT_FIELD is absent.)
+
+All parties MUST reject messages that are not well-formed per the
+rules above.
+
+We do not specify specific TYPE semantics here; we leave those for
+other proposals and specifications.
+
+Parties MUST ignore extensions with `EXT_FIELD_TYPE` bodies they do not
+recognize.
+
+Unless otherwise specified in the documentation for an extension type:
+* Each extension type SHOULD be sent only once in a message.
+* Parties MUST ignore any occurrences all occurrences of an extension
+  with a given type after the first such occurrence.
+* Extensions SHOULD be sent in numerically ascending order by type.
+
+(The above extension sorting and multiplicity rules are only defaults;
+they may be overridden in the description of individual extensions.)
+
+# A.3 How much space is available?
+
+We start with a 498-byte payload in each relay cell.
+
+The header of the EXTEND2 cell, including link specifiers and other
+headers, comes to 89 bytes.
+
+The client handshake requires 128 bytes (excluding CM).
+
+That leaves 281 bytes, "which should be plenty".
+
+# X.1 Negotiating proposal-324 circuit windows
+
+(We should move this section into prop324 when this proposal is
+finished.)
+
+We define a type value, CIRCWINDOW_INC.
+
+We define a triplet of consensus parameters: `circwindow_inc_min`,
+`cincwindow_inc_max`, and `circwindow_inc_dflt`.  These all have
+range (1,65535).
+
+When the authority operators want to experiment with different
+values for `circwindow_inc_dflt`, they set `circwindow_inc_min` and
+`circwindow_inc_max` to the range in which they want to experiment,
+making sure that the existing `circwindow_inc_dflt` is within that
+range.
+
+vWhen a client sees that a relay supports the ntor3 handshake type
+(subprotocol `Relay=X`), and also supports the flow control
+algorithms of proposal 324 (subprotocol `FlowCtrl=X`), then the
+client sends a message, with type `CIRCWINDOW_INC`, containing a
+two-byte integer equal to `circwindow_inc_dflt`.
+
+The relay rejects the message if the value given is outside of the
+\[`circwindow_inc_min`, `circwindow_inc_max`\] range.  Otherwise, it
+accepts it, and replies with the same message that the client sent.
+
+# X.2: Test vectors
+
+The following test values, in hex, were generated by a Python reference
+implementation.
+
+Inputs:
+
+b = "4051daa5921cfa2a1c27b08451324919538e79e788a81b38cbed097a5dff454a"
+B = "f8307a2bc1870b00b828bb74dbb8fd88e632a6375ab3bcd1ae706aaa8b6cdd1d"
+ID = "9fad2af287ef942632833d21f946c6260c33fae6172b60006e86e4a6911753a2"
+x = "b825a3719147bcbe5fb1d0b0fcb9c09e51948048e2e3283d2ab7b45b5ef38b49"
+X = "252fe9ae91264c91d4ecb8501f79d0387e34ad8ca0f7c995184f7d11d5da4f46"
+CM = "68656c6c6f20776f726c64"
+VER = "78797a7a79"
+y = "4865a5b7689dafd978f529291c7171bc159be076b92186405d13220b80e2a053"
+Y = "4bf4814326fdab45ad5184f5518bd7fae25dc59374062698201a50a22954246d"
+SM = "486f6c61204d756e646f"
+
+Intermediate values:
+
+ENC_K1 = "4cd166e93f1c60a29f8fb9ec40ea0fc878930c27800594593e1c4d0f3b5fbd02"
+MAC_K1 = "f5b69e85fdd26e1b0bdbbc8128e32d8123040255f11f744af3cc98fc13613cda"
+msg_mac = "9e044d53565f04d82bbb3bebed3d06cea65db8be9c72b68cd461942088502f67"
+key_seed = "b9a092741098e1f5b8ab37ce74399dd57522c974d7ae4626283a1077b9273255"
+verify = "1dc09fb249738a79f1bc3a545eee8c415f27213894a760bb4df58862e414799a"
+ENC_KEY (server) = "cab8a93eef62246a83536c4384f331ec26061b66098c61421b6cae81f4f57c56"
+AUTH = "2fc5f8773ca824542bc6cf6f57c7c29bbf4e5476461ab130c5b18ab0a9127665"
+
+Messages:
+
+client_handshake = "9fad2af287ef942632833d21f946c6260c33fae6172b60006e86e4a6911753a2f8307a2bc1870b00b828bb74dbb8fd88e632a6375ab3bcd1ae706aaa8b6cdd1d252fe9ae91264c91d4ecb8501f79d0387e34ad8ca0f7c995184f7d11d5da4f463bebd9151fd3b47c180abc9e044d53565f04d82bbb3bebed3d06cea65db8be9c72b68cd461942088502f67"
+
+server_handshake = "4bf4814326fdab45ad5184f5518bd7fae25dc59374062698201a50a22954246d2fc5f8773ca824542bc6cf6f57c7c29bbf4e5476461ab130c5b18ab0a91276651202c3e1e87c0d32054c"
+
+First 256 bytes of keystream:
+
+KEYSTREAM = "9c19b631fd94ed86a817e01f6c80b0743a43f5faebd39cfaa8b00fa8bcc65c3bfeaa403d91acbd68a821bf6ee8504602b094a254392a07737d5662768c7a9fb1b2814bb34780eaee6e867c773e28c212ead563e98a1cd5d5b4576f5ee61c59bde025ff2851bb19b721421694f263818e3531e43a9e4e3e2c661e2ad547d8984caa28ebecd3e4525452299be26b9185a20a90ce1eac20a91f2832d731b54502b09749b5a2a2949292f8cfcbeffb790c7790ed935a9d251e7e336148ea83b063a5618fcff674a44581585fd22077ca0e52c59a24347a38d1a1ceebddbf238541f226b8f88d0fb9c07a1bcd2ea764bbbb5dacdaf5312a14c0b9e4f06309b0333b4a"


### PR DESCRIPTION
As Hybrid Public Key Exchange (HPKE) standards are developing I am trying to keep up with the things that seem most likely to become the standardized structures. [Kyber768-X25519](https://datatracker.ietf.org/doc/html/draft-westerbaan-cfrg-hpke-xyber768d00-03) has been generalized into the [X-Wing](https://datatracker.ietf.org/doc/html/draft-connolly-cfrg-xwing-kem#name-with-hpke-x25519kyber768dra) HPKE.

On top of this I am still adding Kemeleon encoding for the ML-KEM portion and Elligator2 for X25519.