### PR TITLE
O5 handshake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Cargo.lock
 *.perf
 *.data
 *.data.old
+
+**/.vscode
+out.log

--- a/crates/lyrebird/src/fwd/main.rs
+++ b/crates/lyrebird/src/fwd/main.rs
@@ -449,9 +449,7 @@ where
     let client_options = builder.get_client_params();
     let server = builder.build();
 
-    info!(
-        "({obfs4_name}) client params: \"{}\"", client_options
-    );
+    info!("({obfs4_name}) client params: \"{}\"", client_options);
 
     let listener = tokio::net::TcpListener::bind(listen_addrs).await?;
     listeners.push(server_listen_loop::<TcpStream, _, _>(

--- a/crates/lyrebird/src/fwd/main.rs
+++ b/crates/lyrebird/src/fwd/main.rs
@@ -442,15 +442,15 @@ where
     let mut listeners = Vec::new();
 
     let mut builder = Obfs4PT::server_builder();
-    let server = if params.is_some() {
-        builder.options(&params.unwrap())?.build()
-    } else {
-        builder.build()
-    };
+    if params.is_some() {
+        builder.options(&params.unwrap())?;
+    }
+
+    let client_options = builder.get_client_params();
+    let server = builder.build();
 
     info!(
-        "({obfs4_name}) client params: \"{}\"",
-        builder.get_client_params()
+        "({obfs4_name}) client params: \"{}\"", client_options
     );
 
     let listener = tokio::net::TcpListener::bind(listen_addrs).await?;

--- a/crates/lyrebird/src/main.rs
+++ b/crates/lyrebird/src/main.rs
@@ -527,10 +527,10 @@ async fn server_setup(
         }
 
         let mut builder = Obfs4PT::server_builder();
-        let server = builder
+        builder
             .statefile_location(statedir)?
-            .options(&bind_addr.options)?
-            .build();
+            .options(&bind_addr.options)?;
+        let server = builder.build();
 
         let listener = tokio::net::TcpListener::bind(bind_addr.addr).await?;
         listeners.push(server_listen_loop::<TcpStream, _>(

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["tor", "censorship", "pluggable", "transports"]
 categories = ["network-programming", "cryptography"]
 repository = "https://github.com/jmwample/ptrs"
 
+[features]
+default = ["debug"] # TODO: make debug non-default
+debug = ["ptrs/debug"]
 
 [lib]
 name = "o5"
@@ -26,6 +29,7 @@ rand_core = "0.6.4"
 
 ## Crypto
 digest = { version = "0.10.7", features=["mac", "core-api"]}
+generic-array = { version = "0.14.7", features=["zeroize"]}
 typenum = "1.17.0"
 block-buffer = "0.10.4"
 siphasher = "1.0.0"

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -35,6 +35,7 @@ hkdf = "0.12.3"
 crypto_secretbox = { version="0.1.1", features=["chacha20"]}
 subtle = "2.5.0"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets", "getrandom", "reusable_secrets"]}
+x-wing = "0.0.1-alpha"
 
 ## Utils
 pin-project = "1.1.3"

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -54,10 +54,10 @@ tokio-util = { version = "0.7.10", features = ["codec", "io"]}
 bytes = "1.5.0"
 
 ## ntor_arti
-tor-cell = "0.23.0"
-tor-llcrypto = "0.23.0"
-tor-error = "0.23.0"
-tor-bytes = "0.23.0"
+tor-cell = "0.24.0"
+tor-llcrypto = "0.24.0"
+tor-error = "0.24.0"
+tor-bytes = "0.24.0"
 cipher = "0.4.4"
 zeroize = "1.7.0"
 thiserror = "1.0.56"
@@ -74,7 +74,7 @@ kemeleon = { version="0.1.0-rc.1", git="https://github.com/jmwample/kemeleon", b
 anyhow = "1.0"
 tracing-subscriber = "0.3.18"
 hex-literal = "0.4.1"
-tor-basic-utils = "0.22.0"
+tor-basic-utils = "0.24.0"
 
 
 [lints.rust]

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -30,6 +30,7 @@ typenum = "1.17.0"
 block-buffer = "0.10.4"
 siphasher = "1.0.0"
 sha2 = "0.10.8"
+sha3 = "0.10.8"
 hmac = { version="0.12.1", features=["reset"]}
 hkdf = "0.12.3"
 crypto_secretbox = { version="0.1.1", features=["chacha20"]}

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -33,6 +33,7 @@ sha2 = "0.10.8"
 sha3 = "0.10.8"
 hmac = { version="0.12.1", features=["reset"]}
 hkdf = "0.12.3"
+hybrid-array = "0.2.1"
 crypto_secretbox = { version="0.1.1", features=["chacha20"]}
 subtle = "2.5.0"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets", "getrandom", "reusable_secrets"]}
@@ -64,12 +65,12 @@ thiserror = "1.0.56"
 
 curve25519-elligator2 = { version="0.1.0-alpha.1", features=["elligator2"] }
 
-# o5 pqc
+# kemeleon / OKemCore
 ml-kem = { git="https://github.com/jmwample/KEMs", branch="params" }
 kem = "0.3.0-pre.0"
 # kemeleon = { version="0.1.0-rc.1" }
 # kemeleon = { version="0.1.0-rc.1", path="../../../../elligantt/kemeleon"}
-kemeleon = { git="https://github.com/jmwample/kemeleon", branch="uncooking"}
+kemeleon = { git="https://github.com/jmwample/kemeleon", branch="main"}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/o5/Cargo.toml
+++ b/crates/o5/Cargo.toml
@@ -65,10 +65,11 @@ thiserror = "1.0.56"
 curve25519-elligator2 = { version="0.1.0-alpha.1", features=["elligator2"] }
 
 # o5 pqc
-ml-kem = "0.2.1"
+ml-kem = { git="https://github.com/jmwample/KEMs", branch="params" }
 kem = "0.3.0-pre.0"
+# kemeleon = { version="0.1.0-rc.1" }
 # kemeleon = { version="0.1.0-rc.1", path="../../../../elligantt/kemeleon"}
-kemeleon = { version="0.1.0-rc.1", git="https://github.com/jmwample/kemeleon", branch="cleanup"}
+kemeleon = { git="https://github.com/jmwample/kemeleon", branch="uncooking"}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/o5/README.md
+++ b/crates/o5/README.md
@@ -18,29 +18,30 @@ date elements without worrying about being backward compatible.
     - the concept of "packets" is now called "messages"
     - a frame can contain multiple messages
     - update from xsalsa20poly1305 -> chacha20poly1305
-    - padding is given an explicit message type different than that of a payload and uses the mesage length header field
+    - padding is given an explicit message type different than that of a payload message and uses the mesage length header field
       - (In obfs4 a frame that decodes to a payload packet type `\x00` with packet length 0 is asummed to all be padding)
       - move payload to message type `\x01`
       - padding takes message type `\x00`
     - (Maybe) add bidirectional heartbeat messages
+
 - Handshake
-  - x25519 key-exchange -> Kyber1024X25519 key-exchange
+  - x25519 key-exchange -> [X-Wing](https://datatracker.ietf.org/doc/html/draft-connolly-cfrg-xwing-kem#name-with-hpke-x25519kyber768dra) (ML-KEM + X25519) Hybrid Public Key Exchange
     - the overhead padding of the current obfs4 handshake (resulting in paket length in [4096:8192]) is mostly unused
     we exchange some of this unused padding for a kyber key to provide post-quantum security to the handshake.
-    - Are Kyber1024 keys uniform random? I assume not.
-  - NTor V3 handshake
-    - the obfs4 handshake uses (a custom version of) the ntor handshake to derive key materials
-  - (Maybe) change mark and MAC from sha256-128 to sha256
-  - handshake parameters encrypted under the key exchange public keys
+    - [Kemeleon Encoding](https://docs.rs/kemeleon/latest/kemeleon/) for obfuscating ML-KEM public keys and ciphertext on the wire.
+    - [Elligator2](https://docs.rs/curve25519-elligator2/latest/curve25519_elligator2/) for obfuscating X25519 public keys.
+  - [PQ-Obfs handshake](https://eprint.iacr.org/2024/1086.pdf)
+    - Adapted from the [NTor V3 handshake](https://spec.torproject.org/proposals/332-ntor-v3-with-extra-data.html)
+  - Change mark and MAC from sha256-128 to sha3-256
+  - Allow messages extra data to be sent with the handshake, encrypted under the key exchange public keys
     - the client can provide initial parameters during the handshake, knowing that they are not forward secure.
     - the server can provide messages with parameters / extensions in the handshake response (like prngseed)
-    - like the kyber key, this takes space out of the padding already used in the client handshake.
+    - This takes space out of the padding already used in the client handshake.
   - (Maybe) session tickets and resumption
-  - (Maybe) handshake complete frame type
 
 ### Goals
+* Post Quantum Forward Secrecy - traffic captured today cannot be decrypted by a quantum computer tomorrow.
 * Stick closer to Codec / Framed implementation for all packets (hadshake included)
-* use the tor/arti ntor v3 implementation
 
 ### Features to keep
 - once a session is established, unrecognized frame types are ignored

--- a/crates/o5/README.md
+++ b/crates/o5/README.md
@@ -13,8 +13,7 @@ date elements without worrying about being backward compatible.
 ## Differences from obfs4
 
 - Frame / Packet / Message construction
-  - In obfs4 a "frame" consists of a signle "packet", encoded using xsalsa20Poly1305.
-  we use the same frame construction, but change a few key elements:
+  - In obfs4 a "frame" consists of a signle "packet", encoded using xsalsa20Poly1305. We use the same frame construction, but change a few key elements:
     - the concept of "packets" is now called "messages"
     - a frame can contain multiple messages
     - update from xsalsa20poly1305 -> chacha20poly1305
@@ -26,8 +25,7 @@ date elements without worrying about being backward compatible.
 
 - Handshake
   - x25519 key-exchange -> [X-Wing](https://datatracker.ietf.org/doc/html/draft-connolly-cfrg-xwing-kem#name-with-hpke-x25519kyber768dra) (ML-KEM + X25519) Hybrid Public Key Exchange
-    - the overhead padding of the current obfs4 handshake (resulting in paket length in [4096:8192]) is mostly unused
-    we exchange some of this unused padding for a kyber key to provide post-quantum security to the handshake.
+    - the overhead padding of the current obfs4 handshake (resulting in paket length in [4096:8192]) is mostly unused we exchange some of this unused padding for a kyber key to provide post-quantum security to the handshake.
     - [Kemeleon Encoding](https://docs.rs/kemeleon/latest/kemeleon/) for obfuscating ML-KEM public keys and ciphertext on the wire.
     - [Elligator2](https://docs.rs/curve25519-elligator2/latest/curve25519_elligator2/) for obfuscating X25519 public keys.
   - [PQ-Obfs handshake](https://eprint.iacr.org/2024/1086.pdf)

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -4,14 +4,16 @@ use crate::{
     common::colorize,
     constants::*,
     framing::{FrameError, Marshall, O5Codec, TryParse, KEY_LENGTH, KEY_MATERIAL_LENGTH},
-    handshake::IdentityPub,
+    handshake::IdentityPublicKey,
     proto::{MaybeTimeout, O5Stream},
-    sessions, Error, Result,
+    sessions,
+    traits::OKemCore,
+    Digest, Error, Result,
 };
 
 use bytes::{Buf, BufMut, BytesMut};
 use hmac::{Hmac, Mac};
-use kemeleon::{Encode, MlKem768, OKemCore};
+use kemeleon::Encode;
 use ptrs::{debug, info, trace, warn};
 use rand::prelude::*;
 use subtle::ConstantTimeEq;
@@ -21,56 +23,64 @@ use tokio::time::{Duration, Instant};
 use std::{
     fmt,
     io::{Error as IoError, ErrorKind as IoErrorKind},
+    marker::PhantomData,
     pin::Pin,
     sync::{Arc, Mutex},
 };
 
 #[derive(Clone, Debug)]
-pub struct ClientBuilder {
-    pub node_details: IdentityPub,
+pub struct ClientBuilder<K: OKemCore, D: Digest> {
+    pub node_details: Option<IdentityPublicKey<K>>,
     pub statefile_path: Option<String>,
     pub(crate) handshake_timeout: MaybeTimeout,
+
+    pub(crate) _digest: PhantomData<D>,
 }
 
-impl Default for ClientBuilder {
+impl<K: OKemCore, D: Digest> Default for ClientBuilder<K, D> {
     fn default() -> Self {
         Self {
-            node_details: IdentityPub::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])
-                .expect("default identitykey is broken - shouldn't be used anyways"),
+            node_details: None,
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
+            _digest: PhantomData,
         }
     }
 }
 
-impl ClientBuilder {
+impl<K: OKemCore, D: Digest> ClientBuilder<K, D> {
+    pub fn new(pubkey: impl AsRef<[u8]>) -> Result<Self> {
+        Ok(Self {
+            node_details: Some(IdentityPublicKey::<K>::try_from_bytes(pubkey)?),
+            statefile_path: None,
+            handshake_timeout: MaybeTimeout::Default_,
+            _digest: PhantomData,
+        })
+    }
+
     /// TODO: implement client builder from statefile
     pub fn from_statefile(location: &str) -> Result<Self> {
         todo!("this is not implemented");
         Ok(Self {
-            node_details: IdentityPub::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
+            node_details: None,
             statefile_path: Some(location.into()),
             handshake_timeout: MaybeTimeout::Default_,
+            _digest: PhantomData,
         })
     }
 
     /// TODO: implement client builder from string args
     pub fn from_params(param_strs: Vec<impl AsRef<[u8]>>) -> Result<Self> {
         todo!("this is not implemented");
-        Ok(Self {
-            node_details: IdentityPub::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
-            statefile_path: None,
-            handshake_timeout: MaybeTimeout::Default_,
-        })
     }
 
     pub fn with_node_pubkey(&mut self, pubkey: impl AsRef<[u8]>) -> Result<&mut Self> {
-        self.node_details = IdentityPub::try_from_bytes(pubkey)?;
+        self.node_details = Some(IdentityPublicKey::<K>::try_from_bytes(pubkey)?);
         Ok(self)
     }
 
-    pub(crate) fn with_node(&mut self, pubkey: IdentityPub) -> &mut Self {
-        self.node_details = pubkey;
+    pub(crate) fn with_node(&mut self, pubkey: IdentityPublicKey<K>) -> &mut Self {
+        self.node_details = Some(pubkey);
         self
     }
 
@@ -80,7 +90,9 @@ impl ClientBuilder {
     }
 
     pub fn with_node_id(&mut self, id: [u8; NODE_ID_LENGTH]) -> &mut Self {
-        self.node_details.id = id.into();
+        if let Some(d) = self.node_details.as_mut() {
+            d.id = id.into();
+        }
         self
     }
 
@@ -99,10 +111,14 @@ impl ClientBuilder {
         self
     }
 
-    pub fn build(&self) -> Client {
+    pub fn build(&self) -> Client<K, D> {
+        if self.node_details.is_none() {
+            panic!("tried to build client from details missing server identity");
+        }
         Client {
-            station_pubkey: self.node_details.clone(),
+            station_pubkey: self.node_details.clone().unwrap(),
             handshake_timeout: self.handshake_timeout.duration(),
+            _digest: PhantomData,
         }
     }
 
@@ -112,7 +128,7 @@ impl ClientBuilder {
     }
 }
 
-impl fmt::Display for ClientBuilder {
+impl<K: OKemCore, D: Digest> fmt::Display for ClientBuilder<K, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //TODO: string self
         write!(f, "")
@@ -120,18 +136,19 @@ impl fmt::Display for ClientBuilder {
 }
 
 /// Client implementing the obfs4 protocol.
-pub struct Client {
-    station_pubkey: IdentityPub,
+pub struct Client<K: OKemCore, D: Digest> {
+    station_pubkey: IdentityPublicKey<K>,
     handshake_timeout: Option<tokio::time::Duration>,
+    _digest: PhantomData<D>,
 }
 
-impl Client {
+impl<K: OKemCore, D: Digest> Client<K, D> {
     /// TODO: extract args to create new builder
     pub fn get_args(&mut self, _args: &dyn std::any::Any) {}
 
     /// On a failed handshake the client will read for the remainder of the
     /// handshake timeout and then close the connection.
-    pub async fn wrap<'a, T>(self, mut stream: T) -> Result<O5Stream<T, MlKem768>>
+    pub async fn wrap<'a, T>(self, mut stream: T) -> Result<O5Stream<T, K>>
     where
         T: AsyncRead + AsyncWrite + Unpin + 'a,
     {
@@ -139,7 +156,7 @@ impl Client {
 
         let deadline = self.handshake_timeout.map(|d| Instant::now() + d);
 
-        session.handshake::<T>(stream, deadline).await
+        session.handshake::<T, D>(stream, deadline).await
     }
 
     /// On a failed handshake the client will read for the remainder of the
@@ -147,7 +164,7 @@ impl Client {
     pub async fn establish<'a, T, E>(
         self,
         mut stream_fut: Pin<ptrs::FutureResult<T, E>>,
-    ) -> Result<O5Stream<T, MlKem768>>
+    ) -> Result<O5Stream<T, K>>
     where
         T: AsyncRead + AsyncWrite + Unpin + 'a,
         E: std::error::Error + Send + Sync + 'static,
@@ -158,7 +175,7 @@ impl Client {
 
         let deadline = self.handshake_timeout.map(|d| Instant::now() + d);
 
-        session.handshake::<T>(stream, deadline).await
+        session.handshake::<T, D>(stream, deadline).await
     }
 }
 
@@ -167,12 +184,15 @@ mod test {
     use super::*;
     use crate::Result;
 
+    use kemeleon::MlKem768;
+    use sha3::Sha3_256;
+
     #[test]
     fn parse_params() -> Result<()> {
         let test_args = [["", "", ""]];
 
         for (i, test_case) in test_args.iter().enumerate() {
-            let cb = ClientBuilder::from_params(test_case.to_vec())?;
+            let cb = ClientBuilder::<MlKem768, Sha3_256>::from_params(test_case.to_vec())?;
         }
         Ok(())
     }

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use crate::{
-    common::{colorize, mlkem1024_x25519, HmacSha256},
+    common::{colorize, xwing, HmacSha256},
     constants::*,
     framing::{FrameError, Marshall, O5Codec, TryParse, KEY_LENGTH, KEY_MATERIAL_LENGTH},
     handshake::IdentityPublicKey,
@@ -26,8 +26,7 @@ use std::{
 
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
-    pub station_pubkey: [u8; PUBLIC_KEY_LEN],
-    pub station_id: [u8; NODE_ID_LENGTH],
+    pub node_details: IdentityPublicKey,
     pub statefile_path: Option<String>,
     pub(crate) handshake_timeout: MaybeTimeout,
 }
@@ -35,8 +34,8 @@ pub struct ClientBuilder {
 impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
-            station_pubkey: [0u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])
+                .expect("default identitykey is broken - shouldn't be used anyways"),
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         }
@@ -46,9 +45,9 @@ impl Default for ClientBuilder {
 impl ClientBuilder {
     /// TODO: implement client builder from statefile
     pub fn from_statefile(location: &str) -> Result<Self> {
+        todo!("this is not implemented");
         Ok(Self {
-            station_pubkey: [0_u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
             statefile_path: Some(location.into()),
             handshake_timeout: MaybeTimeout::Default_,
         })
@@ -56,16 +55,21 @@ impl ClientBuilder {
 
     /// TODO: implement client builder from string args
     pub fn from_params(param_strs: Vec<impl AsRef<[u8]>>) -> Result<Self> {
+        todo!("this is not implemented");
         Ok(Self {
-            station_pubkey: [0_u8; PUBLIC_KEY_LEN],
-            station_id: [0_u8; NODE_ID_LENGTH],
+            node_details: IdentityPublicKey::new([0u8; PUBLIC_KEY_LEN], [0u8; NODE_ID_LENGTH])?,
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         })
     }
 
-    pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> &mut Self {
-        self.station_pubkey = pubkey;
+    pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> Result<&mut Self> {
+        self.node_details.pk = xwing::PublicKey::try_from(&pubkey[..])?;
+        Ok(self)
+    }
+
+    pub(crate) fn with_node(&mut self, pubkey: IdentityPublicKey) -> &mut Self {
+        self.node_details = pubkey;
         self
     }
 
@@ -75,7 +79,7 @@ impl ClientBuilder {
     }
 
     pub fn with_node_id(&mut self, id: [u8; NODE_ID_LENGTH]) -> &mut Self {
-        self.station_id = id;
+        self.node_details.id = id.into();
         self
     }
 
@@ -96,8 +100,7 @@ impl ClientBuilder {
 
     pub fn build(&self) -> Client {
         Client {
-            station_pubkey: IdentityPublicKey::new(self.station_pubkey, self.station_id)
-                .expect("failed to build client - bad options."),
+            station_pubkey: self.node_details.clone(),
             handshake_timeout: self.handshake_timeout.duration(),
         }
     }

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use bytes::{Buf, BufMut, BytesMut};
 use hmac::{Hmac, Mac};
-use kemeleon::{MlKem768, OKemCore, Encode};
+use kemeleon::{Encode, MlKem768, OKemCore};
 use ptrs::{debug, info, trace, warn};
 use rand::prelude::*;
 use subtle::ConstantTimeEq;
@@ -65,7 +65,7 @@ impl ClientBuilder {
     }
 
     pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> Result<&mut Self> {
-        self.node_details.ek = IdentityPub::try_from_bytes(&pubkey[..])?;
+        self.node_details = IdentityPub::try_from_bytes(&pubkey[..])?;
         Ok(self)
     }
 

--- a/crates/o5/src/client.rs
+++ b/crates/o5/src/client.rs
@@ -64,7 +64,7 @@ impl ClientBuilder {
     }
 
     pub fn with_node_pubkey(&mut self, pubkey: [u8; PUBLIC_KEY_LEN]) -> Result<&mut Self> {
-        self.node_details.pk = xwing::PublicKey::try_from(&pubkey[..])?;
+        self.node_details.ek = xwing::EncapsulationKey::try_from(&pubkey[..])?;
         Ok(self)
     }
 

--- a/crates/o5/src/common/mod.rs
+++ b/crates/o5/src/common/mod.rs
@@ -12,11 +12,11 @@ mod skip;
 pub use skip::discard;
 
 pub mod drbg;
-pub mod mlkem1024_x25519;
 pub mod ntor_arti;
 pub mod probdist;
 pub mod replay_filter;
 pub mod x25519_elligator2;
+pub mod xwing;
 
 pub trait ArgParse {
     type Output;

--- a/crates/o5/src/common/mod.rs
+++ b/crates/o5/src/common/mod.rs
@@ -16,7 +16,7 @@ pub mod ntor_arti;
 pub mod probdist;
 pub mod replay_filter;
 pub mod x25519_elligator2;
-pub mod xwing;
+// pub mod xwing;
 
 pub trait ArgParse {
     type Output;

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -13,10 +13,10 @@
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
 use crate::{
-    common::{colorize, mlkem1024_x25519},
+    common::{colorize, xwing},
     Error, Result,
 };
-//use zeroize::Zeroizing;
+
 use tor_bytes::SecretBuf;
 
 pub const SESSION_ID_LEN: usize = 8;
@@ -70,10 +70,8 @@ pub trait ClientHandshake {
     type HandshakeMaterials: ClientHandshakeMaterials;
     /// The type for the state that the client holds while waiting for a reply.
     type StateType;
-    /// A type that is returned and used to generate session keys.x
-    type KeyGen;
     /// Type of extra data returned by server (without forward secrecy).
-    type ServerAuxData;
+    type HsOutput: ClientHandshakeComplete;
 
     /// Generate a new client onionskin for a relay with a given onion key,
     /// including `client_aux_data` to be sent without forward secrecy.
@@ -81,15 +79,22 @@ pub trait ClientHandshake {
     /// On success, return a state object that will be used to
     /// complete the handshake, along with the message to send.
     fn client1(materials: Self::HandshakeMaterials) -> Result<(Self::StateType, Vec<u8>)>;
+
     /// Handle an onionskin from a relay, and produce aux data returned
     /// from the server, and a key generator.
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(
-        state: Self::StateType,
-        msg: T,
-    ) -> Result<(Self::ServerAuxData, Self::KeyGen)>;
+    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
+}
+
+pub trait ClientHandshakeComplete {
+    type KeyGen;
+    type ServerAuxData;
+    type Remainder;
+    fn keygen(&self) -> &Self::KeyGen;
+    fn extensions(&self) -> &Self::ServerAuxData;
+    fn remainder(&self) -> &Self::Remainder;
 }
 
 /// Trait for an object that handles incoming auxiliary data and
@@ -201,7 +206,7 @@ pub enum RelayHandshakeError {
 
     /// Error happened during cryptographic handshake
     #[error("")]
-    CryptoError(mlkem1024_x25519::EncodeError),
+    CryptoError(xwing::EncodeError),
 
     /// The client asked for a key we didn't have.
     #[error("Client asked for a key or ID that we don't have")]

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -22,7 +22,7 @@ pub struct SessionID([u8; SESSION_ID_LEN]);
 
 impl core::fmt::Display for SessionID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{}]", colorize(hex::encode(&self.0)))
+        write!(f, "[{}]", colorize(hex::encode(self.0)))
     }
 }
 

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -12,10 +12,7 @@
 //! for circuits on today's Tor.
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-use crate::{
-    common::{colorize, xwing},
-    Error, Result,
-};
+use crate::{common::colorize, Error, Result};
 
 use tor_bytes::SecretBuf;
 
@@ -203,10 +200,6 @@ pub enum RelayHandshakeError {
     /// An error in parsing  a handshake message.
     #[error("Problem decoding onion handshake")]
     Fmt(#[from] tor_bytes::Error),
-
-    /// Error happened during cryptographic handshake
-    #[error("")]
-    CryptoError(xwing::EncodeError),
 
     /// The client asked for a key we didn't have.
     #[error("Client asked for a key or ID that we don't have")]

--- a/crates/o5/src/common/ntor_arti.rs
+++ b/crates/o5/src/common/ntor_arti.rs
@@ -85,16 +85,16 @@ pub trait ClientHandshake {
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
+    fn client2<T: AsRef<[u8]>>(state: &mut Self::StateType, msg: T) -> Result<(Self::HsOutput)>;
 }
 
 pub trait ClientHandshakeComplete {
     type KeyGen;
     type ServerAuxData;
     type Remainder;
-    fn keygen(&self) -> &Self::KeyGen;
+    fn keygen(&self) -> Self::KeyGen;
     fn extensions(&self) -> &Self::ServerAuxData;
-    fn remainder(&self) -> &Self::Remainder;
+    fn remainder(&self) -> Self::Remainder;
 }
 
 /// Trait for an object that handles incoming auxiliary data and

--- a/crates/o5/src/common/replay_filter.rs
+++ b/crates/o5/src/common/replay_filter.rs
@@ -245,7 +245,7 @@ mod test {
                 f.filter.len()
             );
             assert!(
-                !f.test_and_set(now, &format!("message-1{i}")),
+                !f.test_and_set(now, format!("message-1{i}")),
                 "unique message failed insert (returned true)"
             );
         }

--- a/crates/o5/src/common/utils.rs
+++ b/crates/o5/src/common/utils.rs
@@ -15,7 +15,7 @@ pub fn get_epoch_hour() -> u64 {
         / 3600
 }
 
-pub fn make_pad(rng: &mut impl CryptoRngCore, pad_len: usize) -> Vec<u8>{
+pub fn make_pad(rng: &mut impl CryptoRngCore, pad_len: usize) -> Vec<u8> {
     trace!("[make_hs_pad] generating {pad_len}B");
     let mut pad = vec![u8::default(); pad_len];
     rng.fill_bytes(&mut pad);

--- a/crates/o5/src/common/utils.rs
+++ b/crates/o5/src/common/utils.rs
@@ -247,7 +247,7 @@ mod test {
         for m in cases {
             let actual = find_mac_mark(
                 m.mark,
-                &Bytes::from(m.buf),
+                Bytes::from(m.buf),
                 m.start_pos,
                 m.max_pos,
                 m.from_tail,

--- a/crates/o5/src/common/utils.rs
+++ b/crates/o5/src/common/utils.rs
@@ -2,7 +2,7 @@ use crate::{constants::*, Result};
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rand_core::RngCore;
+use rand_core::{CryptoRngCore, RngCore};
 use subtle::ConstantTimeEq;
 
 use ptrs::trace;
@@ -15,13 +15,15 @@ pub fn get_epoch_hour() -> u64 {
         / 3600
 }
 
-pub fn make_hs_pad(pad_len: usize) -> Result<Vec<u8>> {
+pub fn make_pad(rng: &mut impl CryptoRngCore, pad_len: usize) -> Vec<u8>{
     trace!("[make_hs_pad] generating {pad_len}B");
     let mut pad = vec![u8::default(); pad_len];
-    rand::thread_rng()
-        .try_fill_bytes(&mut pad)
-        .expect("rng failure");
-    Ok(pad)
+    rng.fill_bytes(&mut pad);
+    pad
+}
+
+pub fn make_hs_pad(pad_len: usize) -> Vec<u8> {
+    make_pad(&mut rand::thread_rng(), pad_len)
 }
 
 pub fn find_mac_mark(

--- a/crates/o5/src/common/xwing.rs
+++ b/crates/o5/src/common/xwing.rs
@@ -40,7 +40,7 @@ struct HybridKey {
 }
 
 #[derive(Clone, PartialEq)]
-pub(crate) struct PublicKey {
+pub struct PublicKey {
     x25519: x25519_dalek::PublicKey,
     mlkem: EncapsulationKey<ml_kem::MlKem1024>,
     pub_key: [u8; PUBKEY_LEN],

--- a/crates/o5/src/common/xwing.rs
+++ b/crates/o5/src/common/xwing.rs
@@ -17,15 +17,14 @@ use crate::{Error, Result};
 
 pub(crate) use kemeleon::EncodeError;
 
-pub struct OKem {
-}
+pub struct OKem {}
 
 pub(crate) const X25519_PUBKEY_LEN: usize = 32;
 pub(crate) const X25519_PRIVKEY_LEN: usize = 32;
-pub(crate) const CIPHERTEXT_LEN: usize =
-    <MlKem768 as KemeleonByteArraySize>::ENCODED_CT_SIZE::USIZE + X25519_PUBKEY_LEN;
-pub(crate) const PUBKEY_LEN: usize =
-    <MlKem768 as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE + X25519_PUBKEY_LEN;
+// pub(crate) const CIPHERTEXT_LEN: usize =
+//     <MlKem768 as KemeleonByteArraySize>::ENCODED_CT_SIZE::USIZE + X25519_PUBKEY_LEN;
+// pub(crate) const PUBKEY_LEN: usize =
+//     <MlKem768 as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE + X25519_PUBKEY_LEN;
 pub(crate) const PRIVKEY_LEN: usize = x_wing::DECAPSULATION_KEY_SIZE;
 pub(crate) const CANONICAL_PUBKEY_LEN: usize = x_wing::ENCAPSULATION_KEY_SIZE;
 pub(crate) const CANONICAL_PRIVKEY_LEN: usize = x_wing::DECAPSULATION_KEY_SIZE;
@@ -196,29 +195,29 @@ impl TryFrom<&[u8]> for DecapsulationKey {
     }
 }
 
-impl TryFrom<&[u8]> for EncapsulationKey {
-    type Error = Error;
-    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
-        if value.len() < PUBKEY_LEN {
-            return Err(Error::Crypto("bad publickey".into()));
-        }
-
-        let mlkem =
-            kemeleon::EncapsulationKey::<MlKem768>::try_from_bytes(&value[X25519_PUBKEY_LEN..])
-                .map_err(|e| Error::EncodeError(e.into()))?;
-
-        let mut pub_key = [0u8; x_wing::ENCAPSULATION_KEY_SIZE];
-        pub_key[..X25519_PUBKEY_LEN].copy_from_slice(&value[..X25519_PUBKEY_LEN]);
-        pub_key[X25519_PUBKEY_LEN..].copy_from_slice(&mlkem.as_fips().as_bytes()[..]);
-
-        let ek = x_wing::EncapsulationKey::from(&pub_key);
-
-        Ok(Self {
-            ek,
-            pub_key_obfs: [0u8; PUBKEY_LEN], // TODO
-        })
-    }
-}
+// impl TryFrom<&[u8]> for EncapsulationKey {
+//     type Error = Error;
+//     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+//         if value.len() < PUBKEY_LEN {
+//             return Err(Error::Crypto("bad publickey".into()));
+//         }
+//
+//         let mlkem =
+//             kemeleon::EncapsulationKey::<MlKem768>::try_from_bytes(&value[X25519_PUBKEY_LEN..])
+//                 .map_err(|e| Error::EncodeError(e.into()))?;
+//
+//         let mut pub_key = [0u8; x_wing::ENCAPSULATION_KEY_SIZE];
+//         pub_key[..X25519_PUBKEY_LEN].copy_from_slice(&value[..X25519_PUBKEY_LEN]);
+//         pub_key[X25519_PUBKEY_LEN..].copy_from_slice(&mlkem.as_fips().as_bytes()[..]);
+//
+//         let ek = x_wing::EncapsulationKey::from(&pub_key);
+//
+//         Ok(Self {
+//             ek,
+//             pub_key_obfs: [0u8; PUBKEY_LEN], // TODO
+//         })
+//     }
+// }
 
 impl TryFrom<[u8; PUBKEY_LEN]> for EncapsulationKey {
     type Error = Error;

--- a/crates/o5/src/common/xwing.rs
+++ b/crates/o5/src/common/xwing.rs
@@ -2,6 +2,7 @@
 //!
 //! todo!
 
+use bytes::BufMut;
 use kem::{Decapsulate, Encapsulate};
 use kemeleon::{
     Encode, EncodingSize, KemeleonByteArraySize, KemeleonEncodingSize, OKemCore, Transcode,
@@ -16,8 +17,13 @@ use crate::{Error, Result};
 
 pub(crate) use kemeleon::EncodeError;
 
+pub struct OKem {
+}
+
 pub(crate) const X25519_PUBKEY_LEN: usize = 32;
 pub(crate) const X25519_PRIVKEY_LEN: usize = 32;
+pub(crate) const CIPHERTEXT_LEN: usize =
+    <MlKem768 as KemeleonByteArraySize>::ENCODED_CT_SIZE::USIZE + X25519_PUBKEY_LEN;
 pub(crate) const PUBKEY_LEN: usize =
     <MlKem768 as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE + X25519_PUBKEY_LEN;
 pub(crate) const PRIVKEY_LEN: usize = x_wing::DECAPSULATION_KEY_SIZE;
@@ -61,6 +67,27 @@ pub fn generate_key_pair(rng: &mut impl CryptoRngCore) -> (DecapsulationKey, Enc
 }
 
 pub struct Ciphertext(x_wing::Ciphertext);
+
+impl Ciphertext {
+    pub fn encode() -> [u8; CIPHERTEXT_LEN] {
+        todo!("closed for cleaning");
+    }
+
+    /// Return byte representation in obfuscated encoded format.
+    pub fn as_bytes(&self) -> &[u8; CIPHERTEXT_LEN] {
+        todo!("hibernating");
+    }
+
+    /// Return byte representation in xwing standard format.
+    pub fn to_bytes_canonical(&self) -> [u8; x_wing::CIPHERTEXT_SIZE] {
+        self.0.as_bytes()
+    }
+
+    /// Return byte representation in obfuscated encoded format.
+    pub fn from_canonical(bytes: &[u8; x_wing::CIPHERTEXT_SIZE]) -> Self {
+        Self(x_wing::Ciphertext::from(bytes))
+    }
+}
 
 impl kem::Decapsulate<Ciphertext, SharedSecret> for DecapsulationKey {
     type Error = Error;
@@ -126,14 +153,19 @@ impl DecapsulationKey {
 }
 
 impl EncapsulationKey {
-    /// Return byte representation in xwing standard format.
-    pub fn to_bytes_canonical(&self) -> [u8; x_wing::ENCAPSULATION_KEY_SIZE] {
-        self.ek.as_bytes()
+    /// Return byte representation in obfuscated encoded format.
+    pub fn encode(&self) -> [u8; PUBKEY_LEN] {
+        self.pub_key_obfs.clone()
     }
 
     /// Return byte representation in obfuscated encoded format.
     pub fn as_bytes(&self) -> &[u8; PUBKEY_LEN] {
         &self.pub_key_obfs
+    }
+
+    /// Return byte representation in xwing standard format.
+    pub fn to_bytes_canonical(&self) -> [u8; x_wing::ENCAPSULATION_KEY_SIZE] {
+        self.ek.as_bytes()
     }
 
     /// Return byte representation in obfuscated encoded format.

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -4,14 +4,14 @@ use tor_llcrypto::pk::ed25519::ED25519_ID_LEN;
 
 pub use crate::common::ntor_arti::SESSION_ID_LEN;
 use crate::{
-    common::{drbg, mlkem1024_x25519, x25519_elligator2::REPRESENTATIVE_LENGTH},
+    common::{drbg, x25519_elligator2::REPRESENTATIVE_LENGTH, xwing},
     framing,
     handshake::AUTHCODE_LENGTH,
 };
 
 use std::time::Duration;
 
-pub const PUBLIC_KEY_LEN: usize = mlkem1024_x25519::PUBKEY_LEN;
+pub const PUBLIC_KEY_LEN: usize = xwing::PUBKEY_LEN;
 
 //=========================[Framing/Msgs]=====================================//
 
@@ -76,4 +76,4 @@ pub const SEED_LENGTH: usize = drbg::SEED_LENGTH;
 pub const HEADER_LENGTH: usize = framing::FRAME_OVERHEAD + framing::MESSAGE_OVERHEAD;
 
 pub const NODE_ID_LENGTH: usize = ED25519_ID_LEN;
-pub const NODE_PUBKEY_LENGTH: usize = mlkem1024_x25519::PUBKEY_LEN;
+pub const NODE_PUBKEY_LENGTH: usize = xwing::PUBKEY_LEN;

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -1,74 +1,58 @@
-#![allow(unused)]
+#![allow(unused)] // TODO: Remove this. nothing unused should stay
+// #![deny(missing_docs)]
 
-use kemeleon::{Encode, KemeleonByteArraySize};
-use ml_kem::MlKem768Params;
+use kemeleon::{Encode, EncodingSize, KemeleonByteArraySize};
+use ml_kem::{Ciphertext, MlKem768Params};
 use tor_llcrypto::pk::ed25519::ED25519_ID_LEN;
 use typenum::Unsigned;
+use digest::OutputSizeUser;
 
 pub use crate::common::ntor_arti::SESSION_ID_LEN;
 use crate::{
     common::{drbg, x25519_elligator2::REPRESENTATIVE_LENGTH},
     framing,
-    handshake::AUTHCODE_LENGTH,
 };
 
-use std::time::Duration;
+use std::{marker::PhantomData, time::Duration};
 
-// TODO: these two should not be necessary
-pub const PUBLIC_KEY_LEN: usize = <MlKem768Params as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE;
-pub const NODE_PUBKEY_LENGTH: usize = PUBLIC_KEY_LEN + ED25519_ID_LEN;
+//=============================[ Framing / Messages =============================//
 
-//=========================[Framing/Msgs]=====================================//
-
-/// Maximum handshake size including padding
-pub const MAX_HANDSHAKE_LENGTH: usize = 8192;
-
-pub const SHA256_SIZE: usize = 32;
-pub const MARK_LENGTH: usize = SHA256_SIZE;
-pub const MAC_LENGTH: usize = SHA256_SIZE;
-
-/// Minimum padding allowed in a client handshake message
-pub const CLIENT_MIN_PAD_LENGTH: usize =
-    (SERVER_MIN_HANDSHAKE_LENGTH + INLINE_SEED_FRAME_LENGTH) - CLIENT_MIN_HANDSHAKE_LENGTH;
-pub const CLIENT_MAX_PAD_LENGTH: usize = MAX_HANDSHAKE_LENGTH - CLIENT_MIN_HANDSHAKE_LENGTH;
-pub const CLIENT_MIN_HANDSHAKE_LENGTH: usize = REPRESENTATIVE_LENGTH + MARK_LENGTH + MAC_LENGTH;
-
-pub const SERVER_MIN_PAD_LENGTH: usize = 0;
-pub const SERVER_MAX_PAD_LENGTH: usize =
-    MAX_HANDSHAKE_LENGTH - (SERVER_MIN_HANDSHAKE_LENGTH + INLINE_SEED_FRAME_LENGTH);
-pub const SERVER_MIN_HANDSHAKE_LENGTH: usize =
-    REPRESENTATIVE_LENGTH + AUTHCODE_LENGTH + MARK_LENGTH + MAC_LENGTH;
-
-pub const INLINE_SEED_FRAME_LENGTH: usize =
-    framing::FRAME_OVERHEAD + MESSAGE_OVERHEAD + SEED_MESSAGE_PAYLOAD_LENGTH;
-
+pub(crate) use framing::FRAME_OVERHEAD;
 pub const MESSAGE_OVERHEAD: usize = 2 + 1;
 pub const MAX_MESSAGE_PAYLOAD_LENGTH: usize = framing::MAX_FRAME_PAYLOAD_LENGTH - MESSAGE_OVERHEAD;
 pub const MAX_MESSAGE_PADDING_LENGTH: usize = MAX_MESSAGE_PAYLOAD_LENGTH;
-pub const SEED_MESSAGE_PAYLOAD_LENGTH: usize = drbg::SEED_LENGTH;
-pub const SEED_MESSAGE_LENGTH: usize =
-    framing::LENGTH_LENGTH + MESSAGE_OVERHEAD + drbg::SEED_LENGTH + MAC_LENGTH;
 
 pub const CONSUME_READ_SIZE: usize = framing::MAX_SEGMENT_LENGTH * 16;
 
-//===============================[Proto]======================================//
+pub const NODE_ID_LENGTH: usize = ED25519_ID_LEN;
+pub const SEED_LENGTH: usize = drbg::SEED_LENGTH;
+pub const HEADER_LENGTH: usize = framing::FRAME_OVERHEAD + framing::MESSAGE_OVERHEAD;
 
-pub const TRANSPORT_NAME: &str = "o5";
+//=================================[ Transport ]=================================//
 
-pub const MARK_ARG: &str = ":05-mc";
-pub const CLIENT_MAC_ARG: &str = ":05-mac_c";
-pub const SERVER_MAC_ARG: &str = ":o5-mac_s";
-pub const SERVER_AUTH_ARG: &str = ":o5-sever_mac";
-pub const KEY_EXTRACT_ARG: &str = ":o5-key_extract";
+pub const CLIENT_MARK_ARG: &[u8] = b":05-mc";
+pub const SERVER_MARK_ARG: &[u8] = b":05-ms";
+pub const CLIENT_MAC_ARG:  &[u8] = b":05-mac_c";
+pub const SERVER_MAC_ARG:  &[u8] = b":o5-mac_s";
+pub const SERVER_AUTH_ARG: &[u8] = b":o5-sever_mac";
+pub const KEY_EXTRACT_ARG: &[u8] = b":o5-key_extract";
+pub const KEY_DERIVE_ARG:  &[u8] = b":o5-derive_key";
 
-pub const NODE_ID_ARG: &str = "node-id";
-pub const PUBLIC_KEY_ARG: &str = "public-key";
+// argument / parameter names
+pub const NODE_ID_ARG:     &str = "node-id";
+pub const PUBLIC_KEY_ARG:  &str = "public-key";
 pub const PRIVATE_KEY_ARG: &str = "private-key";
-pub const SEED_ARG: &str = "drbg-seed";
-pub const CERT_ARG: &str = "cert";
+pub const SEED_ARG:        &str = "drbg-seed";
+pub const CERT_ARG:        &str = "cert";
 
-pub const BIAS_CMD_ARG: &str = "o5-distBias";
+//============================[ Traffic Fingerprint ]============================//
 
+/// Maximum handshake size including padding
+pub const MAX_PACKET_LENGTH: usize = 16_384;
+pub(crate) const MAX_PAD_LENGTH: usize = 8192;
+pub(crate) const MIN_PAD_LENGTH: usize = 0;
+
+// default timeouts
 pub const REPLAY_TTL: Duration = Duration::from_secs(60);
 #[cfg(test)]
 pub const CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -80,10 +64,7 @@ pub const CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 pub const SERVER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub const MAX_IPT_DELAY: usize = 100;
+
+// failed handshake close conditions
 pub const MAX_CLOSE_DELAY: usize = 60;
-pub const MAX_CLOSE_DELAY_BYTES: usize = MAX_HANDSHAKE_LENGTH;
-
-pub const SEED_LENGTH: usize = drbg::SEED_LENGTH;
-pub const HEADER_LENGTH: usize = framing::FRAME_OVERHEAD + framing::MESSAGE_OVERHEAD;
-
-pub const NODE_ID_LENGTH: usize = ED25519_ID_LEN;
+pub const MAX_CLOSE_DELAY_BYTES: usize = MAX_PACKET_LENGTH;

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -19,8 +19,8 @@ pub const PUBLIC_KEY_LEN: usize = xwing::PUBKEY_LEN;
 pub const MAX_HANDSHAKE_LENGTH: usize = 8192;
 
 pub const SHA256_SIZE: usize = 32;
-pub const MARK_LENGTH: usize = SHA256_SIZE / 2;
-pub const MAC_LENGTH: usize = SHA256_SIZE / 2;
+pub const MARK_LENGTH: usize = SHA256_SIZE;
+pub const MAC_LENGTH: usize = SHA256_SIZE;
 
 /// Minimum padding allowed in a client handshake message
 pub const CLIENT_MIN_PAD_LENGTH: usize =
@@ -48,7 +48,13 @@ pub const CONSUME_READ_SIZE: usize = framing::MAX_SEGMENT_LENGTH * 16;
 
 //===============================[Proto]======================================//
 
-pub const TRANSPORT_NAME: &str = "obfs4";
+pub const TRANSPORT_NAME: &str = "o5";
+
+pub const MARK_ARG: &str = ":05-mc";
+pub const CLIENT_MAC_ARG: &str = ":05-mac_c";
+pub const SERVER_MAC_ARG: &str = ":o5-mac_s";
+pub const SERVER_AUTH_ARG: &str = ":o5-sever_mac";
+pub const KEY_EXTRACT_ARG: &str = ":o5-key_extract";
 
 pub const NODE_ID_ARG: &str = "node-id";
 pub const PUBLIC_KEY_ARG: &str = "public-key";
@@ -56,7 +62,7 @@ pub const PRIVATE_KEY_ARG: &str = "private-key";
 pub const SEED_ARG: &str = "drbg-seed";
 pub const CERT_ARG: &str = "cert";
 
-pub const BIAS_CMD_ARG: &str = "obfs4-distBias";
+pub const BIAS_CMD_ARG: &str = "o5-distBias";
 
 pub const REPLAY_TTL: Duration = Duration::from_secs(60);
 #[cfg(test)]

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 
-use kemeleon::{Encode, MlKem768};
+use kemeleon::{Encode, KemeleonByteArraySize};
+use ml_kem::MlKem768Params;
 use tor_llcrypto::pk::ed25519::ED25519_ID_LEN;
 use typenum::Unsigned;
 
@@ -14,7 +15,7 @@ use crate::{
 use std::time::Duration;
 
 // TODO: these two should not be necessary
-pub const PUBLIC_KEY_LEN: usize = <MlKem768::EncapsulationKey as Encode>::EncodedSize::USIZE;
+pub const PUBLIC_KEY_LEN: usize = <MlKem768Params as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE;
 pub const NODE_PUBKEY_LENGTH: usize = PUBLIC_KEY_LEN + ED25519_ID_LEN;
 
 //=========================[Framing/Msgs]=====================================//

--- a/crates/o5/src/constants.rs
+++ b/crates/o5/src/constants.rs
@@ -1,17 +1,21 @@
 #![allow(unused)]
 
+use kemeleon::{Encode, MlKem768};
 use tor_llcrypto::pk::ed25519::ED25519_ID_LEN;
+use typenum::Unsigned;
 
 pub use crate::common::ntor_arti::SESSION_ID_LEN;
 use crate::{
-    common::{drbg, x25519_elligator2::REPRESENTATIVE_LENGTH, xwing},
+    common::{drbg, x25519_elligator2::REPRESENTATIVE_LENGTH},
     framing,
     handshake::AUTHCODE_LENGTH,
 };
 
 use std::time::Duration;
 
-pub const PUBLIC_KEY_LEN: usize = xwing::PUBKEY_LEN;
+// TODO: these two should not be necessary
+pub const PUBLIC_KEY_LEN: usize = <MlKem768::EncapsulationKey as Encode>::EncodedSize::USIZE;
+pub const NODE_PUBKEY_LENGTH: usize = PUBLIC_KEY_LEN + ED25519_ID_LEN;
 
 //=========================[Framing/Msgs]=====================================//
 
@@ -82,4 +86,3 @@ pub const SEED_LENGTH: usize = drbg::SEED_LENGTH;
 pub const HEADER_LENGTH: usize = framing::FRAME_OVERHEAD + framing::MESSAGE_OVERHEAD;
 
 pub const NODE_ID_LENGTH: usize = ED25519_ID_LEN;
-pub const NODE_PUBKEY_LENGTH: usize = xwing::PUBKEY_LEN;

--- a/crates/o5/src/error.rs
+++ b/crates/o5/src/error.rs
@@ -88,7 +88,7 @@ impl Display for Error {
 unsafe impl Send for Error {}
 
 impl Error {
-    pub fn new<T: Into<Box<dyn std::error::Error + Send + Sync>>>(e: T) -> Self {
+    pub fn other<T: Into<Box<dyn std::error::Error + Send + Sync>>>(e: T) -> Self {
         Error::Other(e.into())
     }
 }
@@ -106,7 +106,7 @@ impl FromStr for Error {
     type Err = Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(Error::new(s))
+        Ok(Error::other(s))
     }
 }
 
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_display_other_error() {
-        let err = Error::new("some other error");
+        let err = Error::other("some other error");
         assert_eq!(format!("{}", err), "some other error");
     }
 

--- a/crates/o5/src/error.rs
+++ b/crates/o5/src/error.rs
@@ -209,10 +209,6 @@ impl Error {
     pub(crate) fn from_bytes_err(err: tor_bytes::Error, object: &'static str) -> Error {
         Error::BytesError { err, object }
     }
-
-    pub(crate) fn incomplete_error(_deficit: NonZeroUsize) -> tor_bytes::Error {
-        tor_bytes::Error::Truncated
-    }
 }
 
 #[cfg(test)]

--- a/crates/o5/src/extensions.rs
+++ b/crates/o5/src/extensions.rs
@@ -1,0 +1,1 @@
+//! O5 Extension usage, construction, and utilities

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -1,108 +1,159 @@
 use crate::{
-    common::{
-        utils::{get_epoch_hour, make_pad},
-        HmacSha256,
-    },
+    common::utils::{get_epoch_hour, make_pad},
     constants::*,
+    framing::FrameError,
     handshake::{
-        decrypt, encrypt, Authcode, CHSMaterials, EphemeralPub, SessionSharedSecret,
-        AUTHCODE_LENGTH, ENC_KEY_LEN,
+        encrypt, Authcode, CHSMaterials, EphemeralPub, HandshakeEphemeralSecret,
+        NtorV3Client as Client, SHSMaterials,
     },
-    Error, Result,
+    traits::OKemCore,
+    Digest, Result,
 };
 
-use block_buffer::Eager;
 use bytes::{BufMut, BytesMut};
-use digest::{
-    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
-    HashMarker,
-};
-use hmac::{Hmac, Mac};
-use kem::{Decapsulate, Encapsulate};
-use kemeleon::{Encode, OKemCore};
+use hmac::{Mac, SimpleHmac};
+use kem::Encapsulate;
+use kemeleon::Encode;
 use ptrs::trace;
 use rand::Rng;
 use rand_core::CryptoRngCore;
-use sha3::Sha3_256;
-use tor_bytes::{EncodeError, EncodeResult};
+use tor_bytes::{EncodeError, EncodeResult, Writer};
 use tor_cell::relaycell::extend::NtorV3Extension;
-use typenum::{consts::U256, marker_traits::NonZero, operator_aliases::Le, type_operators::IsLess};
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 use core::borrow::Borrow;
+use core::marker::PhantomData;
 
 // -----------------------------[ Server ]-----------------------------
 
-pub struct ServerHandshakeMessage<K: OKemCore> {
-    server_auth: [u8; AUTHCODE_LENGTH],
-    pad_len: usize,
-    session_pubkey: EphemeralPub<K>,
-    epoch_hour: String,
-    aux_data: Vec<NtorV3Extension>,
+/// Trait allowing for interchangeable server handshake state based on context
+pub trait ShsState {}
+
+/// Used by the client when parsing the handshake sent by the server.
+pub struct ServerHandshakeMessage<K: OKemCore, D: Digest, S: ShsState> {
+    server_ciphertext: K::Ciphertext,
+    server_auth: Authcode<D>,
+    state: S,
+    _digest: PhantomData<D>,
 }
 
-impl<K: OKemCore> ServerHandshakeMessage<K> {
-    pub fn new(_client_pubkey: EphemeralPub<K>, _session_pubkey: EphemeralPub<K>) -> Self {
-        todo!("SHS MSG - this should probably be built directly from the client HS MSG");
-        // Self {
-        //     server_auth: [0u8; AUTHCODE_LENGTH],
-        //     pad_len: rand::thread_rng().gen_range(SERVER_MIN_PAD_LENGTH..SERVER_MAX_PAD_LENGTH),
-        //     epoch_hour: epoch_hr,
-        // }
-    }
+/// State tracked when constructing and sending an outgoing server handshake
+pub struct ServerStateOutgoing<'a, D: Digest> {
+    pub(crate) pad_len: usize,
+    /// Ciphertext created as part of the KEM handshake where the server uses the encapsulation key
+    /// sent by the client in the client hallo message to share a session shared secret.
+    pub(crate) ephemeral_secret: HandshakeEphemeralSecret<D>,
+    pub(crate) encrypted_extension_reply: Vec<u8>,
+    pub(crate) hs_materials: &'a SHSMaterials,
+}
+impl<D: Digest> ShsState for ServerStateOutgoing<'_, D> {}
 
-    pub fn with_pad_len(&mut self, pad_len: usize) -> &Self {
-        self.pad_len = pad_len;
-        self
-    }
+/// State tracked when parsing and operating on an incoming server handshake
+pub struct ServerStateIncoming {}
+impl ShsState for ServerStateIncoming {}
 
-    pub fn with_aux_data(&mut self, aux_data: Vec<NtorV3Extension>) -> &Self {
-        self.aux_data = aux_data;
-        self
+impl<'a, D: Digest, K: OKemCore, S: ShsState> ServerHandshakeMessage<K, D, S> {
+    pub fn new(server_ciphertext: K::Ciphertext, server_auth: Authcode<D>, state: S) -> Self {
+        Self {
+            server_ciphertext,
+            server_auth,
+            state,
+            _digest: PhantomData,
+        }
     }
+}
 
-    pub fn server_pubkey(&mut self) -> EphemeralPub<K> {
-        self.session_pubkey.clone()
-    }
+impl<'a, D: Digest, K: OKemCore> ServerHandshakeMessage<K, D, ServerStateOutgoing<'a, D>> {
+    /// Serialize the Server Hello Message
+    ///
+    /// Given a properly processed client handshake, the Server handshake is then constructed as:
+    ///
+    ///    MSG = Enc_chacha20poly1305(ES, [extensions])
+    ///    AUTH = F1(FS, context | PROTOID | ":server_mac")
+    ///    Ms = F1(ES, CTso | ":ms")
+    ///    MACs = F1(ES, CTso | auth | MSG | Ps | Ms | E | ":mac_s" )
+    ///    OUT = CTso | auth | MSG | Ps | Ms | MACs
+    ///
+    /// where
+    ///     EKc   client's encapsulation key NOT obfuscated
+    ///     CTc   client ciphertext encoded NOT obfuscated
+    ///     EKs   server's Identity Encapsulation key NOT obfuscated
+    ///     CTs   ciphertext created by the server using the client session key NOT obfuscated
+    ///     CTso  ciphertext created by the server using the client session key, obfuscated
+    ///     Ps    N ∈ [serverMinPadLength,serverMaxPadLength] bytes of random padding.
+    ///     E     string representation of the number of hours since the UNIX epoch
+    pub fn marshall(&self, rng: &mut impl CryptoRngCore, buf: &mut impl BufMut) -> Result<()> {
+        // -------------------------------- [ ST-PQ-OBFS ] -------------------------------- //
+        // Security Theoretic, KEM, Obfuscated Key exchange
 
-    pub fn server_auth(self) -> Authcode {
-        self.server_auth
-    }
-
-    pub fn marshall(&mut self, _buf: &mut impl BufMut, mut _h: HmacSha256) -> Result<()> {
         trace!("serializing server handshake");
-        todo!("marshall server hello");
 
-        // h.reset();
-        // h.update(self.session_pubkey.as_bytes().as_ref());
-        // let mark: &[u8] = &h.finalize_reset().into_bytes()[..MARK_LENGTH];
+        let ephemeral_secret = &self.state.ephemeral_secret;
 
-        // // The server handshake is Y | AUTH | P_S | M_S | MAC(Y | AUTH | P_S | M_S | E) where:
-        // //  * Y is the server's ephemeral Curve25519 public key representative.
-        // //  * AUTH is the ntor handshake AUTH value.
-        // //  * P_S is [serverMinPadLength,serverMaxPadLength] bytes of random padding.
-        // //  * M_S is HMAC-SHA256-128(serverIdentity | NodeID, Y)
-        // //  * MAC is HMAC-SHA256-128(serverIdentity | NodeID, Y .... E)
-        // //  * E is the string representation of the number of hours since the UNIX
-        // //    epoch.
+        let ciphertext = &self.server_ciphertext;
 
-        // // Generate the padding
-        // let pad: &[u8] = &make_pad(rng, self.pad_len)?;
+        // set up our hash fn
+        let mut f1_es = SimpleHmac::<D>::new_from_slice(ephemeral_secret.as_ref())
+            .expect("keying hmac should never fail");
 
-        // // Write Y, AUTH, P_S, M_S.
-        // let mut params = vec![];
-        // params.extend_from_slice(self.session_pubkey.as_bytes());
-        // params.extend_from_slice(&self.server_auth);
-        // params.extend_from_slice(pad);
-        // params.extend_from_slice(mark);
-        // buf.put(params.as_slice());
+        // compute the Mark
+        let mark = {
+            f1_es.reset();
+            f1_es.update(&ciphertext.as_bytes());
+            f1_es.update(SERVER_MARK_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
 
-        // // Calculate and write MAC
-        // h.update(&params);
-        // h.update(self.epoch_hour.as_bytes());
-        // buf.put(&h.finalize_reset().into_bytes()[..MAC_LENGTH]);
+        // Generate the padding
+        let pad = make_pad(rng, self.state.pad_len);
 
-        // Ok(())
+        // Write CTso, AUTH, MSG_REPLY, P_s, M_s
+        let hello_msg = {
+            let mut hello_msg = Vec::new();
+            hello_msg
+                .write(&ciphertext.as_bytes()[..])
+                .and_then(|_| hello_msg.write(&self.server_auth[..]))
+                .and_then(|_| hello_msg.write(&self.state.encrypted_extension_reply))
+                .and_then(|_| hello_msg.write(&pad))
+                .and_then(|_| hello_msg.write(&mark))
+                .map_err(|_| {
+                    FrameError::FailedToMarshall("failed to encode server handshake".into())
+                })?;
+            hello_msg
+        };
+        buf.put(hello_msg.as_slice());
+
+        // Calculate and write MAC
+        let mac = {
+            f1_es.reset();
+            f1_es.update(&hello_msg);
+            f1_es.update(get_epoch_hour().to_string().as_bytes());
+            f1_es.update(SERVER_MAC_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
+        buf.put(&mac[..]);
+
+        trace!(
+            "{} - mark: {}, mac: {}",
+            self.state.hs_materials.session_id,
+            hex::encode(mark),
+            hex::encode(mac)
+        );
+
+        // //------------------------------------[NTORv3]-------------------------------
+
+        // let (enc_key, keystream) = {
+        //     let mut xof = DigestWriter(Shake256::default());
+        //     xof.write(&T_FINAL)
+        //         .and_then(|_| xof.write(&ntor_key_seed))
+        //         .map_err(into_internal!("can't generate ntor3 xof."))?;
+        //     let mut r = xof.take().finalize_xof();
+        //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
+        //     r.read(&mut enc_key[..]);
+        //     (enc_key, r)
+        // };
+
+        Ok(())
     }
 }
 
@@ -110,40 +161,94 @@ impl<K: OKemCore> ServerHandshakeMessage<K> {
 
 /// Preliminary message sent in an obfs4 handshake attempting to open a
 /// connection from a client to a potential server.
-pub struct ClientHandshakeMessage<K: OKemCore> {
-    hs_materials: CHSMaterials<K>,
+pub struct ClientHandshakeMessage<K: OKemCore, S: ChsState> {
     client_session_pubkey: EphemeralPub<K>,
+    state: S,
 
     // only used when parsing (i.e. on the server side)
     pub(crate) epoch_hour: String,
 }
 
-impl<K> ClientHandshakeMessage<K>
+/// Trait allowing for interchangeable client handshake state based on context
+pub trait ChsState {}
+
+/// State tracked when constructing and sending an outgoing client handshake
+pub struct ClientStateOutgoing<K: OKemCore> {
+    pub(crate) hs_materials: CHSMaterials<K>,
+}
+impl<K: OKemCore> ChsState for ClientStateOutgoing<K> {}
+
+/// State tracked when parsing and operating on an incoming client handshake
+pub struct ClientStateIncoming<D: Digest> {
+    ephemeral_secret: HandshakeEphemeralSecret<D>,
+    extensions: Vec<NtorV3Extension>,
+}
+impl<D: Digest> ChsState for ClientStateIncoming<D> {}
+
+impl<D: Digest> ClientStateIncoming<D> {
+    pub(crate) fn new(ephemeral_secret: HandshakeEphemeralSecret<D>) -> Self {
+        Self {
+            ephemeral_secret,
+            extensions: Vec::new(),
+        }
+    }
+}
+
+impl<K, D: Digest> ClientHandshakeMessage<K, ClientStateIncoming<D>>
 where
     K: OKemCore,
-    <K as OKemCore>::EncapsulationKey: Clone,
+    <K as kemeleon::OKemCore>::EncapsulationKey: Clone, // TODO: Is this necessary?
 {
     pub(crate) fn new(
         client_session_pubkey: EphemeralPub<K>,
-        hs_materials: CHSMaterials<K>,
+        state: ClientStateIncoming<D>,
+        epoch_hour: Option<String>,
     ) -> Self {
         Self {
-            hs_materials,
             client_session_pubkey,
-
-            // only used when parsing (i.e. on the server side)
-            epoch_hour: get_epoch_hour().to_string(),
+            state,
+            epoch_hour: epoch_hour.unwrap_or(get_epoch_hour().to_string()),
         }
     }
 
+    pub(crate) fn get_ephemeral_secret(&self) -> HandshakeEphemeralSecret<D> {
+        self.state.ephemeral_secret.clone()
+    }
+
+    pub(crate) fn get_extensions(&self) -> Vec<u8> {
+        vec![] // TODO: Flesh out extension serialization
+    }
+}
+
+impl<K: OKemCore, S: ChsState> ClientHandshakeMessage<K, S>
+where
+    K: OKemCore,
+{
     pub fn get_public(&mut self) -> EphemeralPub<K> {
-        // trace!("repr: {}", hex::encode(self.client_session_pubkey.id);
         self.client_session_pubkey.clone()
     }
 
     /// return the epoch hour used in the ntor handshake.
     pub fn get_epoch_hr(&self) -> String {
         self.epoch_hour.clone()
+    }
+}
+
+impl<K> ClientHandshakeMessage<K, ClientStateOutgoing<K>>
+where
+    K: OKemCore,
+{
+    pub(crate) fn new(
+        client_session_pubkey: EphemeralPub<K>,
+        state: ClientStateOutgoing<K>,
+    ) -> Self {
+        Self {
+            client_session_pubkey,
+            state,
+
+            // only used when parsing (i.e. on the server side)
+            epoch_hour: get_epoch_hour().to_string(),
+        }
     }
 
     /// The client handshake is constructed as:
@@ -158,58 +263,61 @@ where
     ///    CTco is  client_ciphertext_obfuscated
     ///    E is the string representation of the number of hours since the UNIX epoch.
     ///    P_C is [clientMinPadLength,clientMaxPadLength] bytes of random padding.
-    pub fn marshall(
+    pub fn marshall<D: Digest>(
         &mut self,
         rng: &mut impl CryptoRngCore,
         buf: &mut impl BufMut,
-    ) -> EncodeResult<Zeroizing<[u8; ENC_KEY_LEN]>> {
+    ) -> EncodeResult<HandshakeEphemeralSecret<D>> {
         trace!("serializing client handshake");
-        self.marshall_inner::<Sha3_256>(rng, buf)
+        self.marshall_inner::<D>(rng, buf)
     }
 
-    fn marshall_inner<D>(
+    fn marshall_inner<D: Digest>(
         &mut self,
         rng: &mut impl CryptoRngCore,
         buf: &mut impl BufMut,
-    ) -> EncodeResult<Zeroizing<[u8; ENC_KEY_LEN]>>
-    where
-        D: CoreProxy,
-        D::Core: HashMarker
-            + UpdateCore
-            + FixedOutputCore
-            + BufferKindUser<BufferKind = Eager>
-            + Default
-            + Clone,
-        <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
-        Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
-    {
+    ) -> EncodeResult<HandshakeEphemeralSecret<D>> {
         // serialize our extensions into a message
         let mut message = BytesMut::new();
-        NtorV3Extension::write_many_onto(self.hs_materials.aux_data.borrow(), &mut message)?;
+        NtorV3Extension::write_many_onto(self.state.hs_materials.aux_data.borrow(), &mut message)?;
 
         // -------------------------------- [ ST-PQ-OBFS ] -------------------------------- //
         // Security Theoretic, Post-Quantum safe, Obfuscated Key exchange
 
-        let node_encap_key = &self.hs_materials.node_pubkey.ek;
-        let node_id = &self.hs_materials.node_pubkey.id;
+        let node_encap_key = &self.state.hs_materials.node_pubkey.ek;
+        let node_id = &self.state.hs_materials.node_pubkey.id;
         let (ciphertext, shared_secret) = node_encap_key.encapsulate(rng).map_err(to_tor_err)?;
+        let shared_secret = &shared_secret.as_bytes()[..];
+
+        trace!("id_pubkey: {}", hex::encode(&node_encap_key.as_bytes()[..]));
 
         // compute our ephemeral secret
-        let mut h =
-            Hmac::<D>::new_from_slice(node_id.as_bytes()).expect("keying hmac should never fail");
-        h.update(&shared_secret.as_bytes()[..]);
-        let mut ephemeral_secret = Zeroizing::new([0u8; ENC_KEY_LEN]);
-        ephemeral_secret.copy_from_slice(&h.finalize_reset().into_bytes()[..ENC_KEY_LEN]);
-
-        // set up our hash fn
-        let mut f1_es = Hmac::<D>::new_from_slice(ephemeral_secret.as_ref())
+        let mut f2 = SimpleHmac::<D>::new_from_slice(node_id.as_bytes())
             .expect("keying hmac should never fail");
 
+        let ephemeral_secret = {
+            f2.reset();
+            f2.update(shared_secret);
+            Zeroizing::new(f2.finalize_reset().into_bytes())
+        };
+
+        trace!("shared secret: {}", hex::encode(shared_secret));
+
+        // set up our hash fn
+        let mut f1_es = SimpleHmac::<D>::new_from_slice(ephemeral_secret.as_ref())
+            .expect("keying hmac should never fail");
+
+        let ek_bytes: &[u8] = &self.client_session_pubkey.as_bytes()[..];
+        let ct_bytes: &[u8] = &ciphertext.as_bytes()[..];
+
         // compute the Mark
-        f1_es.update(&self.client_session_pubkey.as_bytes()[..]);
-        f1_es.update(&ciphertext.as_bytes()[..]);
-        f1_es.update(MARK_ARG.as_bytes());
-        let mark = f1_es.finalize_reset().into_bytes();
+        let mark = {
+            f1_es.reset();
+            f1_es.update(ek_bytes);
+            f1_es.update(ct_bytes);
+            f1_es.update(CLIENT_MARK_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
 
         // Encrypt the message (Extensions etc.)
         //
@@ -217,32 +325,35 @@ where
         // identity secret key is leaked this text can be decrypted. Once we receive the
         // server response w/ secrets based on ephemeral (session) secrets any further data has
         // forward secrecy.
-        let encrypted_msg = encrypt(&ephemeral_secret, &message);
+        let encrypted_msg = encrypt::<D>(&ephemeral_secret, &message);
 
         // Generate the padding
-        let pad_len = rng.gen_range(CLIENT_MIN_PAD_LENGTH..CLIENT_MAX_PAD_LENGTH); // TODO - recalculate these
+        let pad_len = rng.gen_range(MIN_PAD_LENGTH..Client::<K, D>::CLIENT_MAX_PAD_LENGTH); // TODO - recalculate these
         let pad = make_pad(rng, pad_len);
 
         // Write EKco, CTco, MSG, P_C, M_C
-        let mut params = vec![];
-        params.extend_from_slice(&self.client_session_pubkey.as_bytes()[..]);
-        params.extend_from_slice(&ciphertext.as_bytes()[..]);
-        params.extend_from_slice(&message);
-        params.extend_from_slice(&pad);
-        params.extend_from_slice(&mark);
-        buf.put(params.as_slice());
+        let hello_msg = {
+            let mut hello_msg = Vec::new();
+            hello_msg.write(ek_bytes);
+            hello_msg.write(ct_bytes);
+            hello_msg.write(&encrypted_msg);
+            hello_msg.write(&pad);
+            hello_msg.write(&mark);
+            hello_msg
+        };
+        buf.put(hello_msg.as_slice());
 
         // Calculate and write MAC
-        f1_es.update(&params);
+        f1_es.update(&hello_msg);
         self.epoch_hour = format!("{}", get_epoch_hour());
         f1_es.update(self.epoch_hour.as_bytes());
-        f1_es.update(CLIENT_MAC_ARG.as_bytes());
+        f1_es.update(CLIENT_MAC_ARG);
         let mac = f1_es.finalize_reset().into_bytes();
         buf.put(&mac[..]);
 
         trace!(
             "{} - mark: {}, mac: {}",
-            self.hs_materials.session_id,
+            self.state.hs_materials.session_id,
             hex::encode(mark),
             hex::encode(mac)
         );
@@ -257,9 +368,3 @@ fn to_tor_err(e: impl core::fmt::Debug) -> EncodeError {
         format!("cryptographic encapsulation error: {e:?}"),
     ))
 }
-// The client handshake is X | P_C | M_C | MAC(X | P_C | M_C | E) where:
-//  * X is the client's ephemeral Curve25519 public key representative.
-//  * P_C is [clientMinPadLength,clientMaxPadLength] bytes of random padding.
-//  * M_C is HMAC-SHA256-128(serverIdentity | NodeID, X)
-//  * MAC is HMAC-SHA256-128(serverIdentity | NodeID, X .... E)
-//  * E is the string representation of the number of hours since the UNIX epoch.

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -108,7 +108,7 @@ pub struct ClientHandshakeMessage<'a> {
 }
 
 impl<'a> ClientHandshakeMessage<'a> {
-    pub fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
+    pub(crate) fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
         Self {
             hs_materials,
             client_session_pubkey,

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -108,7 +108,10 @@ pub struct ClientHandshakeMessage<'a> {
 }
 
 impl<'a> ClientHandshakeMessage<'a> {
-    pub(crate) fn new(client_session_pubkey: SessionPublicKey, hs_materials: &'a CHSMaterials) -> Self {
+    pub(crate) fn new(
+        client_session_pubkey: SessionPublicKey,
+        hs_materials: &'a CHSMaterials,
+    ) -> Self {
         Self {
             hs_materials,
             client_session_pubkey,

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -8,14 +8,17 @@ use crate::{
     Result,
 };
 
-use bytes::BufMut;
 use block_buffer::Eager;
-use digest::{core_api::{BlockSizeUser, CoreProxy, UpdateCore, FixedOutputCore, BufferKindUser}, HashMarker};
+use bytes::BufMut;
+use digest::{
+    core_api::{BlockSizeUser, BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore},
+    HashMarker,
+};
 use hmac::{Hmac, Mac};
 use ptrs::trace;
-use typenum::{consts::U256, operator_aliases::Le, type_operators::IsLess, marker_traits::NonZero};
 use tor_cell::relaycell::extend::NtorV3Extension;
 use tor_llcrypto::d::Sha3_256;
+use typenum::{consts::U256, marker_traits::NonZero, operator_aliases::Le, type_operators::IsLess};
 
 // -----------------------------[ Server ]-----------------------------
 
@@ -125,11 +128,7 @@ impl<'a> ClientHandshakeMessage<'a> {
         self.epoch_hour.clone()
     }
 
-    pub fn marshall(
-        &mut self,
-        buf: &mut impl BufMut,
-        key: &[u8],
-    ) -> Result<()> {
+    pub fn marshall(&mut self, buf: &mut impl BufMut, key: &[u8]) -> Result<()> {
         trace!("serializing client handshake");
 
         let h = Hmac::<Sha3_256>::new_from_slice(key).unwrap();
@@ -140,7 +139,12 @@ impl<'a> ClientHandshakeMessage<'a> {
     pub fn marshall_inner<D>(&mut self, _buf: &mut impl BufMut, _h: Hmac<D>) -> Result<()>
     where
         D: CoreProxy,
-        D::Core: HashMarker + UpdateCore + FixedOutputCore + BufferKindUser<BufferKind = Eager> + Default + Clone,
+        D::Core: HashMarker
+            + UpdateCore
+            + FixedOutputCore
+            + BufferKindUser<BufferKind = Eager>
+            + Default
+            + Clone,
         <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
         Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
     {

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -33,7 +33,7 @@ use core::borrow::Borrow;
 
 // -----------------------------[ Server ]-----------------------------
 
-pub struct ServerHandshakeMessage<K:OKemCore> {
+pub struct ServerHandshakeMessage<K: OKemCore> {
     server_auth: [u8; AUTHCODE_LENGTH],
     pad_len: usize,
     session_pubkey: EphemeralPub<K>,
@@ -41,7 +41,7 @@ pub struct ServerHandshakeMessage<K:OKemCore> {
     aux_data: Vec<NtorV3Extension>,
 }
 
-impl<K:OKemCore> ServerHandshakeMessage<K> {
+impl<K: OKemCore> ServerHandshakeMessage<K> {
     pub fn new(_client_pubkey: EphemeralPub<K>, _session_pubkey: EphemeralPub<K>) -> Self {
         todo!("SHS MSG - this should probably be built directly from the client HS MSG");
         // Self {
@@ -136,7 +136,7 @@ where
         }
     }
 
-    pub fn get_public(&mut self) -> K::EncapsulationKey {
+    pub fn get_public(&mut self) -> EphemeralPub<K> {
         // trace!("repr: {}", hex::encode(self.client_session_pubkey.id);
         self.client_session_pubkey.clone()
     }
@@ -197,7 +197,7 @@ where
         // compute our ephemeral secret
         let mut h =
             Hmac::<D>::new_from_slice(node_id.as_bytes()).expect("keying hmac should never fail");
-        h.update(shared_secret.as_bytes());
+        h.update(&shared_secret.as_bytes()[..]);
         let mut ephemeral_secret = Zeroizing::new([0u8; ENC_KEY_LEN]);
         ephemeral_secret.copy_from_slice(&h.finalize_reset().into_bytes()[..ENC_KEY_LEN]);
 

--- a/crates/o5/src/framing/handshake.rs
+++ b/crates/o5/src/framing/handshake.rs
@@ -19,7 +19,7 @@ use digest::{
 };
 use hmac::{Hmac, Mac};
 use kem::{Decapsulate, Encapsulate};
-use kemeleon::OKemCore;
+use kemeleon::{OKemCore, Encode};
 use ptrs::trace;
 use rand::Rng;
 use rand_core::CryptoRngCore;
@@ -206,7 +206,7 @@ where
             .expect("keying hmac should never fail");
 
         // compute the Mark
-        f1_es.update(self.client_session_pubkey.as_bytes());
+        f1_es.update(&self.client_session_pubkey.as_bytes());
         f1_es.update(ciphertext.as_bytes());
         f1_es.update(MARK_ARG.as_bytes());
         let mark = f1_es.finalize_reset().into_bytes();
@@ -225,8 +225,8 @@ where
 
         // Write EKco, CTco, MSG, P_C, M_C
         let mut params = vec![];
-        params.extend_from_slice(self.client_session_pubkey.as_bytes());
-        params.extend_from_slice(ciphertext.as_bytes());
+        params.extend_from_slice(&self.client_session_pubkey.as_bytes());
+        params.extend_from_slice(&ciphertext.as_bytes());
         params.extend_from_slice(&message);
         params.extend_from_slice(&pad);
         params.extend_from_slice(&mark);

--- a/crates/o5/src/framing/messages_v1/mod.rs
+++ b/crates/o5/src/framing/messages_v1/mod.rs
@@ -5,6 +5,8 @@ use crate::{
     framing::{FrameError, MESSAGE_OVERHEAD},
 };
 
+mod prng_seed;
+
 use tokio_util::bytes::{Buf, BufMut};
 use tracing::trace;
 

--- a/crates/o5/src/framing/messages_v1/prng_seed.rs
+++ b/crates/o5/src/framing/messages_v1/prng_seed.rs
@@ -1,0 +1,13 @@
+//! PRNG Seed message
+//!
+//! Message that a server will send upon successful completion of a handshake
+//! giving the client a value with which to seed the pseudo-random number generator
+//! that is used for selecting padding lengths.
+
+use crate::{common::drbg, constants::*};
+
+pub const SEED_MESSAGE_PAYLOAD_LENGTH: usize = drbg::SEED_LENGTH;
+pub const INLINE_SEED_FRAME_LENGTH: usize =
+    FRAME_OVERHEAD + MESSAGE_OVERHEAD + SEED_MESSAGE_PAYLOAD_LENGTH;
+
+pub struct PrngSeedMessage([u8; SEED_LENGTH]);

--- a/crates/o5/src/framing/mod.rs
+++ b/crates/o5/src/framing/mod.rs
@@ -108,16 +108,19 @@ pub enum FrameError {
     /// is the error returned when [`encode`] rejects the payload length.
     InvalidPayloadLength(usize),
 
-    /// A cryptographic error occured.
+    /// A cryptographic error occurred.
     Crypto(crypto_secretbox::Error),
 
-    /// An error occured with the I/O processing
+    /// Failed to marshall a frame or packet,
+    FailedToMarshall(String),
+
+    /// An error occurred with the I/O processing
     IO(String),
 
     /// Returned when [`decode`] requires more data to continue.
     EAgain,
 
-    /// Returned when [`decode`] failes to authenticate a frame.
+    /// Returned when [`decode`] failed to authenticate a frame.
     TagMismatch,
 
     /// Returned when the NaCl secretbox nonce's counter wraps (FATAL).
@@ -127,7 +130,7 @@ pub enum FrameError {
     ShortBuffer,
 
     /// Error indicating that a message decoded, or a message provided for
-    /// encoding is of an innapropriate type for the context.
+    /// encoding is of an inappropriate type for the context.
     InvalidMessage,
 
     /// Failed while trying to parse a handshake message
@@ -147,6 +150,7 @@ impl std::fmt::Display for FrameError {
                 write!(f, "framing: Invalid payload length: {s}")
             }
             FrameError::Crypto(e) => write!(f, "framing: Secretbox encrypt/decrypt error: {e}"),
+            FrameError::FailedToMarshall(s) => write!(f, "Frame or Packet failed to marshall: {s}"),
             FrameError::IO(e) => {
                 write!(f, "framing: i/o error occured while processing frame: {e}")
             }

--- a/crates/o5/src/handshake.rs
+++ b/crates/o5/src/handshake.rs
@@ -21,18 +21,18 @@ pub(crate) use keys::{Authcode, NtorV3KeyGenerator, AUTHCODE_LENGTH};
 pub use keys::{IdentityPublicKey, IdentitySecretKey, NtorV3KeyGen};
 
 /// Super trait to be used where we require a distinction between client and server roles.
-trait Role {
+pub trait Role {
     fn is_client() -> bool;
 }
 
-struct ClientRole {}
+pub struct ClientRole {}
 impl Role for ClientRole {
     fn is_client() -> bool {
         true
     }
 }
 
-struct ServerRole {}
+pub struct ServerRole {}
 impl Role for ServerRole {
     fn is_client() -> bool {
         false

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -1,25 +1,32 @@
+//! Client specific handshake handling implementations.
+
 use std::marker::PhantomData;
+use std::time::Instant;
 
 use crate::{
     common::{
         ct,
         ntor_arti::{
             ClientHandshake, ClientHandshakeComplete, ClientHandshakeMaterials, KeyGenerator,
+            RelayHandshakeError, RelayHandshakeResult,
         },
+        utils::{find_mac_mark, get_epoch_hour},
     },
     constants::*,
-    framing::handshake::ClientHandshakeMessage,
-    handshake::keys::*,
-    handshake::*,
-    Error, Result,
+    framing::handshake::{
+        ClientHandshakeMessage, ClientStateOutgoing, ServerHandshakeMessage, ServerStateIncoming,
+    },
+    handshake::{keys::*, *},
+    traits::{DigestSizes, FramingSizes, OKemCore},
+    Digest, Error, Result, Server,
 };
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use digest::CtOutput;
-use hmac::{Hmac, Mac};
+use hmac::{Mac, SimpleHmac};
 use kem::{Decapsulate, Encapsulate};
-use kemeleon::{Encode, OKemCore};
-// use cipher::KeyIvInit;
+use kemeleon::Encode;
+use ptrs::{debug, trace};
 use rand::{CryptoRng, Rng, RngCore};
 use rand_core::CryptoRngCore;
 use subtle::ConstantTimeEq;
@@ -30,17 +37,16 @@ use tor_llcrypto::{
     d::{Sha3_256, Shake256, Shake256Reader},
     pk::ed25519::Ed25519Identity,
 };
+use typenum::Unsigned;
 use zeroize::Zeroizing;
 
 /// Client state for the o5 (ntor v3) handshake.
 ///
 /// The client needs to hold this state between when it sends its part
 /// of the handshake and when it receives the relay's reply.
-pub(crate) struct HandshakeState<K: OKemCore> {
+pub(crate) struct HandshakeState<K: OKemCore, D: Digest> {
     /// The temporary curve25519 secret (x) that we've generated for
     /// this handshake.
-    // We'd like to EphemeralSecret here, but we can't since we need
-    // to use it twice.
     my_sk: EphemeralKey<K>,
 
     /// handshake materials
@@ -50,11 +56,14 @@ pub(crate) struct HandshakeState<K: OKemCore> {
     epoch_hr: String,
 
     /// The shared secret generated as F2(node_id, encapsulation_key)
-    ephemeral_secret: Zeroizing<[u8; ENC_KEY_LEN]>,
+    ephemeral_secret: HandshakeEphemeralSecret<D>,
+
+    /// client hello message that we sent, used again after receiving the server hello.
+    client_hs_msg: BytesMut,
 }
 
-impl<K: OKemCore> HandshakeState<K> {
-    fn node_pubkey(&self) -> &<K as OKemCore>::EncapsulationKey {
+impl<K: OKemCore, D: Digest> HandshakeState<K, D> {
+    fn node_pubkey(&self) -> &<K as kemeleon::OKemCore>::EncapsulationKey {
         &self.materials.node_pubkey.ek
     }
 
@@ -67,7 +76,6 @@ impl<K: OKemCore> HandshakeState<K> {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct HandshakeMaterials<K: OKemCore> {
     pub(crate) node_pubkey: IdentityPublicKey<K>,
-    pub(crate) pad_len: usize,
     pub(crate) session_id: String,
     pub(crate) aux_data: Vec<NtorV3Extension>,
 }
@@ -77,7 +85,6 @@ impl<K: OKemCore> HandshakeMaterials<K> {
         HandshakeMaterials {
             node_pubkey: node_pubkey.clone(),
             session_id,
-            pad_len: rand::thread_rng().gen_range(CLIENT_MIN_PAD_LENGTH..CLIENT_MAX_PAD_LENGTH),
             aux_data: vec![],
         }
     }
@@ -85,6 +92,10 @@ impl<K: OKemCore> HandshakeMaterials<K> {
     pub fn with_early_data(mut self, data: impl AsRef<[NtorV3Extension]>) -> Self {
         self.aux_data = data.as_ref().to_vec();
         self
+    }
+
+    pub(crate) fn get_identity(&self) -> IdentityPublicKey<K> {
+        self.node_pubkey.clone()
     }
 }
 
@@ -102,8 +113,9 @@ impl<K: OKemCore> ClientHandshakeMaterials for HandshakeMaterials<K> {
 }
 
 /// Client side of the ntor v3 handshake.
-pub(crate) struct NtorV3Client<K: OKemCore> {
+pub(crate) struct NtorV3Client<K: OKemCore, D: Digest> {
     _okem: PhantomData<K>,
+    _digest: PhantomData<D>,
 }
 
 /// State resulting from successful client handshake.
@@ -128,8 +140,8 @@ impl ClientHandshakeComplete for HsComplete {
     }
 }
 
-impl<K: OKemCore> ClientHandshake for NtorV3Client<K> {
-    type StateType = HandshakeState<K>;
+impl<K: OKemCore, D: Digest> ClientHandshake for NtorV3Client<K, D> {
+    type StateType = HandshakeState<K, D>;
     type HandshakeMaterials = HandshakeMaterials<K>;
     type HsOutput = HsComplete;
 
@@ -138,13 +150,14 @@ impl<K: OKemCore> ClientHandshake for NtorV3Client<K> {
     ///
     /// On success, return a state object that will be used to complete the handshake, along
     /// with the message to send.
-    fn client1(hs_materials: Self::HandshakeMaterials) -> Result<(Self::StateType, Vec<u8>)> {
+    fn client1<B: BufMut>(
+        hs_materials: Self::HandshakeMaterials,
+        out: &mut B,
+    ) -> Result<Self::StateType> {
         let mut rng = rand::thread_rng();
 
-        Ok(
-            client_handshake_ntor_v3::<K>(&mut rng, hs_materials, NTOR3_CIRC_VERIFICATION)
-                .map_err(into_internal!("Can't encode ntor3 client handshake."))?,
-        )
+        Ok(Self::client_handshake_ntor_v3(&mut rng, hs_materials, out)
+            .map_err(into_internal!("Can't encode ntor3 client handshake."))?)
     }
 
     /// Handle an onionskin from a relay, and produce a key generator.
@@ -152,8 +165,7 @@ impl<K: OKemCore> ClientHandshake for NtorV3Client<K> {
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
     fn client2<T: AsRef<[u8]>>(state: &mut Self::StateType, msg: T) -> Result<Self::HsOutput> {
-        let (message, xof_reader) =
-            client_handshake_ntor_v3_part2::<K>(state, msg.as_ref(), NTOR3_CIRC_VERIFICATION)?;
+        let (message, xof_reader) = Self::client_handshake_ntor_v3_part2(msg, state)?;
         let extensions = NtorV3Extension::decode(&message).map_err(|err| Error::CellDecodeErr {
             object: "ntor v3 extensions",
             err,
@@ -167,128 +179,334 @@ impl<K: OKemCore> ClientHandshake for NtorV3Client<K> {
     }
 }
 
-/// Client-side Ntor version 3 handshake, part one.
-///
-/// Given a secure `rng`, a relay's public key, a secret message to send,
-/// and a shared verification string, generate a new handshake state
-/// and a message to send to the relay.
-pub(crate) fn client_handshake_ntor_v3<K: OKemCore>(
-    rng: &mut impl CryptoRngCore,
-    materials: HandshakeMaterials<K>,
-    verification: &[u8],
-) -> EncodeResult<(HandshakeState<K>, Vec<u8>)> {
-    let keys = K::generate(rng);
-    client_handshake_ntor_v3_no_keygen::<K>(rng, keys, materials, verification)
+impl<K: OKemCore, D: Digest> NtorV3Client<K, D> {
+    const CT_SIZE: usize = K::CT_SIZE;
+    const EK_SIZE: usize = K::EK_SIZE;
+    const AUTH_SIZE: usize = D::AUTH_SIZE;
+    pub const CLIENT_MIN_HANDSHAKE_LENGTH: usize =
+        K::EK_SIZE + K::CT_SIZE + D::MARK_SIZE + D::MAC_SIZE;
+    pub const CLIENT_MAX_PAD_LENGTH: usize = MAX_PAD_LENGTH - Self::CLIENT_MIN_HANDSHAKE_LENGTH;
+
+    /// Client-side Ntor version 3 handshake, part one.
+    ///
+    /// Given a secure `rng`, a relay's public key, a secret message to send, generate a new handshake
+    /// state and a message to send to the relay.
+    pub(crate) fn client_handshake_ntor_v3<Out: BufMut>(
+        rng: &mut impl CryptoRngCore,
+        materials: HandshakeMaterials<K>,
+        out_buf: &mut Out,
+    ) -> EncodeResult<HandshakeState<K, D>> {
+        let keys = K::generate(rng);
+        Self::client_handshake_ntor_v3_no_keygen(rng, keys, materials, out_buf)
+    }
+
+    /// As `client_handshake_ntor_v3`, but don't generate an ephemeral DH
+    /// key: instead take that key an arguments `my_sk`.
+    ///
+    /// (DK, EK , EK1) <-- OKEM.KGen()
+    pub(crate) fn client_handshake_ntor_v3_no_keygen<Out: BufMut>(
+        rng: &mut impl CryptoRngCore,
+        keys: (K::DecapsulationKey, K::EncapsulationKey),
+        materials: HandshakeMaterials<K>,
+        out_buf: &mut Out,
+    ) -> EncodeResult<HandshakeState<K, D>> {
+        let ephemeral_ek = EphemeralPub::new(keys.1);
+        let hs_materials = ClientStateOutgoing {
+            hs_materials: materials.clone(),
+        };
+        let mut client_msg =
+            ClientHandshakeMessage::<K, ClientStateOutgoing<K>>::new(ephemeral_ek, hs_materials);
+
+        // ------------ [ Perform Handshake and Serialize Packet ] ------------ //
+
+        let mut buf = BytesMut::with_capacity(MAX_PACKET_LENGTH);
+        let ephemeral_secret = client_msg.marshall::<D>(rng, &mut buf)?;
+
+        out_buf.put(buf.clone());
+
+        let state = HandshakeState {
+            materials,
+            my_sk: keys::EphemeralKey::new(keys.0),
+            ephemeral_secret,
+            epoch_hr: client_msg.get_epoch_hr(),
+            client_hs_msg: buf,
+        };
+
+        Ok(state)
+    }
+
+    /// Finalize the handshake on the client side.
+    ///
+    /// Called after we've received a message from the relay: try to
+    /// complete the handshake and verify its correctness.
+    ///
+    /// On success, return the server's reply to our original encrypted message,
+    /// and an `XofReader` to use in generating circuit keys.
+    pub(crate) fn client_handshake_ntor_v3_part2(
+        relay_handshake: impl AsRef<[u8]>,
+        state: &HandshakeState<K, D>,
+    ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
+        let msg = relay_handshake.as_ref();
+        if Server::<K, D>::SERVER_MIN_HANDSHAKE_LENGTH > msg.len() {
+            Err(RelayHandshakeError::EAgain)?;
+        }
+
+        let mut server_hs = match Self::try_parse_server_handshake(msg, state) {
+            Ok(shs) => shs,
+            Err(RelayHandshakeError::EAgain) => {
+                return Err(RelayHandshakeError::EAgain);
+            }
+            Err(_e) => {
+                debug!(
+                    "{} failed to parse server handshake: {_e}",
+                    state.materials.session_id
+                );
+                return Err(RelayHandshakeError::BadClientHandshake);
+            }
+        };
+
+        debug!(
+            "{} successfully parsed server handshake",
+            state.materials.session_id
+        );
+
+        // get the chunk containing the ciphertext
+        let mut server_ct_obfs = &msg[0..K::CT_SIZE];
+
+        // get the chunk containing the server's authentication
+        let mut server_auth = &msg[K::CT_SIZE..K::CT_SIZE + D::AUTH_SIZE];
+
+        // decode and decapsulate the secret encoded by the server
+        let server_ct = <K as kemeleon::OKemCore>::Ciphertext::try_from_bytes(server_ct_obfs)
+            .map_err(|e| RelayHandshakeError::FailedParse)?;
+        let shared_secret_2 = state
+            .my_sk
+            .decapsulate(&server_ct)
+            .map_err(|e| RelayHandshakeError::FailedDecapsulation)?;
+
+        let mut f1_es = SimpleHmac::<D>::new_from_slice(state.ephemeral_secret.as_ref())
+            .expect("keying hmac should never fail");
+
+        // compute the Session Ephemeral Secret
+        let derivation_ephemeral = {
+            f1_es.reset();
+            f1_es.update(&KEY_DERIVE_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
+
+        let mut f2 = SimpleHmac::<D>::new_from_slice(derivation_ephemeral.as_ref())
+            .expect("keying hmac should never fail");
+
+        // compute our Combiner Ephemeral Secret
+        let combiner_ephemeral = {
+            f2.reset();
+            f2.update(&shared_secret_2.as_bytes()[..]);
+            Zeroizing::new(f2.finalize_reset().into_bytes())
+        };
+
+        // Handshake context = EKco || CTco || EKso || CTso || protocol_id
+        let mut context = {
+            let mut c = SecretBuf::new();
+
+            let client_context_elements = &state.client_hs_msg[K::EK_SIZE..K::EK_SIZE + K::CT_SIZE];
+            c.write(client_context_elements) // EKco || CTco from client handshake
+                .and_then(|_| c.write(&state.node_pubkey().as_bytes()[..])) // EKso server identity key
+                .and_then(|_| c.write(server_ct_obfs)) // CTso server created ciphertext
+                .and_then(|_| c.write(Server::<K, D>::protocol_id().as_bytes())) // protocol ID
+                .map_err(|_| {
+                    RelayHandshakeError::FrameError("failed to wire reply context".into())
+                })?;
+            c
+        };
+
+        let mut f1_fs = SimpleHmac::<D>::new_from_slice(combiner_ephemeral.as_ref())
+            .expect("keying hmac should never fail");
+
+        // Compute the Session Key value used to key our cipher.
+        let session_key = {
+            f1_fs.reset();
+            f1_fs.update(&context[..]);
+            f1_fs.update(KEY_EXTRACT_ARG);
+            Zeroizing::new(f1_fs.finalize_reset().into_bytes())
+        };
+
+        // Compute the Server message authentication value
+        let computed_auth = {
+            f1_fs.reset();
+            f1_fs.update(&context[..]);
+            f1_fs.update(SERVER_AUTH_ARG);
+            f1_fs.finalize_reset().into_bytes()
+        };
+
+        let err = match <subtle::Choice as Into<bool>>::into(computed_auth.ct_eq(&server_auth)) {
+            // // TODO: If an Ellyptic Curve scheme (i.e. X25519) is involved
+            // // make sure that the clients mac matches and that both x25519 keys
+            // & ct::bool_to_choice(yx.was_contributory())
+            // & ct::bool_to_choice(state.shared_secret.was_contributory());
+            true => None,
+            false => {
+                trace!(
+                    "{} != {}",
+                    hex::encode(&computed_auth),
+                    hex::encode(&server_auth)
+                );
+                Some(RelayHandshakeError::ServerAuthMismatch)
+            }
+        };
+
+        let (enc_key, keystream) = {
+            use digest::{ExtendableOutput, Update, XofReader};
+            let mut xof = Shake256::default();
+            xof.update(&T_FINAL);
+            xof.update(&session_key);
+            let mut r = xof.finalize_xof();
+            let mut enc_key = SessionSharedSecret::<D>::default();
+            r.read(&mut enc_key[..]);
+            (enc_key, r)
+        };
+
+        // Decrypt extension messages and give them to the client.
+        // TODO PARSE EXTENSIONS
+        // let server_reply = decrypt(&enc_key, encrypted_msg);
+
+        if err.is_none() {
+            Ok((Vec::new(), NtorV3XofReader::new(keystream)))
+        } else {
+            Err(err.unwrap())
+        }
+    }
 }
 
-/// As `client_handshake_ntor_v3`, but don't generate an ephemeral DH
-/// key: instead take that key an arguments `my_sk`.
-///
-/// (DK, EK , EK1) <-- OKEM.KGen()
-pub(crate) fn client_handshake_ntor_v3_no_keygen<K: OKemCore>(
-    rng: &mut impl CryptoRngCore,
-    keys: (K::DecapsulationKey, K::EncapsulationKey),
-    materials: HandshakeMaterials<K>,
-    verification: &[u8],
-) -> EncodeResult<(HandshakeState<K>, Vec<u8>)> {
-    let ephemeral_ek = EphemeralPub::new(keys.1);
-    let mut client_msg = ClientHandshakeMessage::<K>::new(ephemeral_ek, materials.clone());
+impl<K: OKemCore, D: Digest> NtorV3Client<K, D> {
+    fn try_parse_server_handshake(
+        b: impl AsRef<[u8]>,
+        state: &HandshakeState<K, D>,
+    ) -> RelayHandshakeResult<ServerHandshakeMessage<K, D, ServerStateIncoming>> {
+        let buf = b.as_ref();
 
-    // ------------ [ Perform Handshake and Serialize Packet ] ------------ //
+        if Server::<K, D>::SERVER_MIN_HANDSHAKE_LENGTH > buf.len() {
+            Err(RelayHandshakeError::EAgain)?;
+        }
 
-    let mut buf = BytesMut::with_capacity(MAX_HANDSHAKE_LENGTH);
-    let ephemeral_secret = client_msg.marshall(rng, &mut buf)?;
+        let mut server_ct_obfs = vec![0u8; Self::CT_SIZE];
+        server_ct_obfs.copy_from_slice(&buf[..Self::CT_SIZE]);
 
-    let state = HandshakeState {
-        materials,
-        my_sk: keys::EphemeralKey::new(keys.0),
-        ephemeral_secret,
-        epoch_hr: client_msg.get_epoch_hr(),
-    };
+        // chunk off the ciphertext
+        let mut server_ct_obfs = vec![0u8; Self::CT_SIZE];
+        server_ct_obfs.copy_from_slice(&buf[0..Self::CT_SIZE]);
 
-    Ok((state, buf.to_vec()))
-}
+        // chunk off server authentication value
+        let mut server_auth =
+            Authcode::<D>::clone_from_slice(&buf[Self::CT_SIZE..Self::CT_SIZE + Self::AUTH_SIZE]);
+        // server_auth.copy_from_slice(
+        //     &buf[Self::CT_SIZE..Self::CT_SIZE + Authcode::<D>::USIZE],
+        // );
 
-/// Finalize the handshake on the client side.
-///
-/// Called after we've received a message from the relay: try to
-/// complete the handshake and verify its correctness.
-///
-/// On success, return the server's reply to our original encrypted message,
-/// and an `XofReader` to use in generating circuit keys.
-pub(crate) fn client_handshake_ntor_v3_part2<K: OKemCore>(
-    state: &HandshakeState<K>,
-    relay_handshake: &[u8],
-    verification: &[u8],
-) -> Result<(Vec<u8>, NtorV3XofReader)> {
-    todo!("client handshake part 2");
+        // decode and decapsulate the secret encoded by the server
+        let server_ct = <K as kemeleon::OKemCore>::Ciphertext::try_from_bytes(&server_ct_obfs)
+            .map_err(|e| RelayHandshakeError::FailedParse)?;
+        let shared_secret_1 = state
+            .my_sk
+            .decapsulate(&server_ct)
+            .map_err(|e| RelayHandshakeError::FailedDecapsulation)?;
 
-    // let mut reader = Reader::from_slice(relay_handshake);
-    // let y_pk: EphemeralPub::<K> = reader
-    //     .extract()
-    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    // let auth: DigestVal = reader
-    //     .extract()
-    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    // let encrypted_msg = reader.into_rest();
-    // let my_public = EphemeralPub::<K>::from(&state.my_sk);
+        let node_id = state.materials.get_identity().id;
+        let mut f2 = SimpleHmac::<D>::new_from_slice(node_id.as_bytes())
+            .expect("keying server f2 hmac should never fail");
 
-    // // TODO: Some of this code is duplicated from the server handshake code!  It
-    // // would be better to factor it out.
-    // let yx = state.my_sk.diffie_hellman(&y_pk);
-    // let secret_input = {
-    //     let mut si = SecretBuf::new();
-    //     si.write(&yx)
-    //         .and_then(|_| si.write(&state.shared_secret.as_bytes()))
-    //         .and_then(|_| si.write(&state.node_id()))
-    //         .and_then(|_| si.write(&state.node_pubkey().as_bytes()))
-    //         .and_then(|_| si.write(&my_public.as_bytes()))
-    //         .and_then(|_| si.write(&y_pk.as_bytes()))
-    //         .and_then(|_| si.write(PROTOID))
-    //         .and_then(|_| si.write(&Encap(verification)))
-    //         .map_err(into_internal!("error encoding ntor3 secret_input"))?;
-    //     si
-    // };
-    // let ntor_key_seed = h_key_seed(&secret_input);
-    // let verify = h_verify(&secret_input);
+        let mut f1_es = SimpleHmac::<Sha3_256>::new_from_slice(state.ephemeral_secret.as_ref())
+            .expect("Keying server f1_es hmac should never fail");
 
-    // let computed_auth: DigestVal = {
-    //     use digest::Digest;
-    //     let mut auth = DigestWriter(Sha3_256::default());
-    //     auth.write(&T_AUTH)
-    //         .and_then(|_| auth.write(&verify))
-    //         .and_then(|_| auth.write(&state.node_id()))
-    //         .and_then(|_| auth.write(&state.node_pubkey().as_bytes()))
-    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
-    //         .and_then(|_| auth.write(&my_public.as_bytes()))
-    //         .and_then(|_| auth.write(&state.msg_mac))
-    //         .and_then(|_| auth.write(&Encap(encrypted_msg)))
-    //         .and_then(|_| auth.write(PROTOID))
-    //         .and_then(|_| auth.write(&b"Server"[..]))
-    //         .map_err(into_internal!("error encoding ntor3 authentication input"))?;
-    //     auth.take().finalize().into()
-    // };
+        // derive the mark from the Ephemeral Secret
+        let server_mark = {
+            f1_es.reset();
+            f1_es.update(&server_ct_obfs);
+            f1_es.update(SERVER_MARK_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
 
-    // let okay = computed_auth.ct_eq(&auth)
-    //     & ct::bool_to_choice(yx.was_contributory())
-    //     & ct::bool_to_choice(state.shared_secret.was_contributory());
+        trace!(
+            "client-{} mark?:{}",
+            state.materials.session_id,
+            hex::encode(server_mark)
+        );
 
-    // let (enc_key, keystream) = {
-    //     use digest::{ExtendableOutput, XofReader};
-    //     let mut xof = DigestWriter(Shake256::default());
-    //     xof.write(&T_FINAL)
-    //         .and_then(|_| xof.write(&ntor_key_seed))
-    //         .map_err(into_internal!("error encoding ntor3 xof input"))?;
-    //     let mut r = xof.take().finalize_xof();
-    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-    //     r.read(&mut enc_key[..]);
-    //     (enc_key, r)
-    // };
-    // let server_reply = decrypt(&enc_key, encrypted_msg);
+        let min_position = Server::<K, D>::SERVER_MIN_HANDSHAKE_LENGTH;
 
-    // if okay.into() {
-    //     Ok((server_reply, NtorV3XofReader::new(keystream)))
-    // } else {
-    //     Err(Error::BadCircHandshakeAuth)
-    // }
+        // find mark + mac position
+        let pos = match find_mac_mark::<D>(server_mark, buf, min_position, MAX_PACKET_LENGTH, true)
+        {
+            Some(p) => p,
+            None => {
+                trace!("{} didn't find mark", state.materials.session_id);
+                if buf.len() > MAX_PACKET_LENGTH {
+                    Err(RelayHandshakeError::BadServerHandshake)?
+                }
+                Err(RelayHandshakeError::EAgain)?
+            }
+        };
+
+        // // TODO: should this use state.epoch_hr? Do we even need to try multiple time stamps??
+        // validate he MAC
+        let mut mac_found = false;
+        let mut epoch_hour = String::new();
+        for offset in [0_i64, -1, 1] {
+            // Allow the epoch to be off by up to one hour in either direction
+            trace!("server trying offset: {offset}");
+            let eh = format!("{}", offset + get_epoch_hour() as i64);
+
+            // compute the expected MAC (if the epoch hour is within the valid range)
+            f1_es.reset();
+            f1_es.update(&buf[..pos + D::MARK_SIZE]);
+            f1_es.update(eh.as_bytes());
+            f1_es.update(SERVER_MAC_ARG);
+            let mac_calculated = &f1_es.finalize_reset().into_bytes()[..D::MAC_SIZE];
+
+            // check received mac
+            let mac_received = &buf[pos + D::MARK_SIZE..pos + D::MARK_SIZE + D::MAC_SIZE];
+            trace!(
+                "server {}-{}",
+                hex::encode(mac_calculated),
+                hex::encode(mac_received)
+            );
+
+            // // TODO: If an Ellyptic Curve scheme (i.e. X25519) is involved
+            // // make sure that the clients mac matches and that both x25519 keys
+            // // contributed (i.e. neither was 0)
+            // let mut okay = computed_mac.ct_eq(&msg_mac)
+            //     & ct::bool_to_choice(xy.was_contributory())
+            //     & ct::bool_to_choice(xb.was_contributory());
+
+            // make sure that the servers mac matches
+            if mac_calculated.ct_eq(mac_received).into() {
+                trace!("correct mac");
+                epoch_hour = eh;
+                mac_found = true;
+
+                // We break here, but if this creates some kind of timing channel
+                // (not sure exactly what that would be) we could reduce timing variance by
+                // just evaluating all three MACs. Probably not necessary
+                break;
+            }
+        }
+
+        if !mac_found {
+            // This could be a [`RelayHandshakeError::TagMismatch`] :shrug:
+            trace!("Matching MAC not found");
+            Err(RelayHandshakeError::BadServerHandshake)?
+        }
+
+        // // TODO: Not sure if this is valid
+        // // server should never send any appended padding at the end.
+        // if buf.len() != pos + MARK_LENGTH + MAC_LENGTH {
+        //     trace!("server sent extra data");
+        //     Err(RelayHandshakeError::BadServerHandshake)?
+        // }
+
+        Ok(ServerHandshakeMessage::<K, D, ServerStateIncoming>::new(
+            server_ct,
+            server_auth,
+            ServerStateIncoming {},
+        ))
+    }
 }

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -52,7 +52,7 @@ pub(crate) struct HandshakeState<K: OKemCore> {
     epoch_hr: String,
 
     /// The shared secret generated as F2(node_id, encapsulation_key)
-    ephemeral_secret: K::SharedKey,
+    ephemeral_secret: Zeroizing<[u8;ENC_KEY_LEN]>,
 }
 
 impl<K: OKemCore> HandshakeState<K> {
@@ -199,8 +199,7 @@ pub(crate) fn client_handshake_ntor_v3_no_keygen<K>(
 where
     K: OKemCore,
 {
-    let node_pubkey = materials.node_pubkey;
-    let mut client_msg = ClientHandshakeMessage::<K>::new(keys.1, &materials);
+    let mut client_msg = ClientHandshakeMessage::<K>::new(keys.1, materials.clone());
 
     // ------------ [ Perform Handshake and Serialize Packet ] ------------ //
 

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::{
         ct,
-        mlkem1024_x25519::SharedSecret,
-        ntor_arti::{ClientHandshake, ClientHandshakeMaterials},
+        ntor_arti::{ClientHandshake, ClientHandshakeComplete, ClientHandshakeMaterials},
+        xwing::SharedSecret,
     },
     constants::*,
     framing::handshake::ClientHandshakeMessage,
@@ -25,7 +25,6 @@ use tor_llcrypto::{
     pk::ed25519::Ed25519Identity,
 };
 use zeroize::Zeroizing;
-
 
 /// Client state for the o5 (ntor v3) handshake.
 ///
@@ -52,7 +51,7 @@ pub(crate) struct HandshakeState {
 }
 
 impl HandshakeState {
-    fn node_pubkey(&self) -> &mlkem1024_x25519::PublicKey {
+    fn node_pubkey(&self) -> &xwing::PublicKey {
         &self.materials.node_pubkey.pk
     }
 
@@ -102,11 +101,31 @@ impl ClientHandshakeMaterials for HandshakeMaterials {
 /// Client side of the ntor v3 handshake.
 pub(crate) struct NtorV3Client;
 
-impl ClientHandshake for NtorV3Client {
-    type StateType = HandshakeState;
+/// State resulting from successful client handshake.
+pub struct HsComplete {
+    keygen: NtorV3KeyGenerator,
+    extensions: Vec<NtorV3Extension>,
+    remainder: (),
+}
+impl ClientHandshakeComplete for HsComplete {
     type KeyGen = NtorV3KeyGenerator;
     type ServerAuxData = Vec<NtorV3Extension>;
+    type Remainder = ();
+    fn keygen(&self) -> &Self::KeyGen {
+        &self.keygen
+    }
+    fn extensions(&self) -> &Self::ServerAuxData {
+        &self.extensions
+    }
+    fn remainder(&self) -> &Self::Remainder {
+        &self.remainder
+    }
+}
+
+impl ClientHandshake for NtorV3Client {
+    type StateType = HandshakeState;
     type HandshakeMaterials = HandshakeMaterials;
+    type HsOutput = HsComplete;
 
     /// Generate a new client onionskin for a relay with a given onion key.
     /// If any `extensions` are provided, encode them into to the onionskin.
@@ -126,10 +145,7 @@ impl ClientHandshake for NtorV3Client {
     ///
     /// The state object must match the one that was used to make the
     /// client onionskin that the server is replying to.
-    fn client2<T: AsRef<[u8]>>(
-        state: Self::StateType,
-        msg: T,
-    ) -> Result<(Vec<NtorV3Extension>, Self::KeyGen)> {
+    fn client2<T: AsRef<[u8]>>(state: Self::StateType, msg: T) -> Result<Self::HsOutput> {
         let (message, xofreader) =
             client_handshake_ntor_v3_part2(&state, msg.as_ref(), NTOR3_CIRC_VERIFICATION)?;
         let extensions = NtorV3Extension::decode(&message).map_err(|err| Error::CellDecodeErr {
@@ -138,7 +154,11 @@ impl ClientHandshake for NtorV3Client {
         })?;
         let keygen = NtorV3KeyGenerator::new::<ClientRole>(xofreader);
 
-        Ok((extensions, keygen))
+        Ok(HsComplete {
+            extensions,
+            keygen,
+            remainder: (),
+        })
     }
 }
 
@@ -163,50 +183,52 @@ pub(crate) fn client_handshake_ntor_v3_no_keygen(
     materials: HandshakeMaterials,
     verification: &[u8],
 ) -> EncodeResult<(HandshakeState, Vec<u8>)> {
-    let my_public = SessionPublicKey::from(&my_sk);
-    let client_msg = ClientHandshakeMessage::new(my_public.clone(), &materials);
+    todo!("client handshake part 1");
 
-    // --------
-    let node_pubkey = materials.node_pubkey();
-    // let bx = my_sk.diffie_hellman(&node_pubkey);
-    let mut rng = rand::thread_rng();
-    let (ct, bx) = my_sk.hpke(&mut rng, materials.node_pubkey.pk)?;
-    // .map_err(|e| Error::Crypto(e.to_string()));
+    // let my_public = SessionPublicKey::from(&my_sk);
+    // let client_msg = ClientHandshakeMessage::new(my_public.clone(), &materials);
 
-    let (enc_key, mut mac) = kdf_msgkdf(&bx, node_pubkey, &my_public, verification)?;
+    // // --------
+    // let node_pubkey = materials.node_pubkey();
+    // // let bx = my_sk.diffie_hellman(&node_pubkey);
+    // let mut rng = rand::thread_rng();
+    // let (ct, bx) = my_sk.hpke(&mut rng, materials.node_pubkey.pk)?;
+    // // .map_err(|e| Error::Crypto(e.to_string()));
 
-    // encrypted_msg = ENC(ENC_K1, CM)
-    // msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
-    let encrypted_msg = encrypt(&enc_key, client_msg);
-    let msg_mac: DigestVal = {
-        use digest::Digest;
-        mac.write(&encrypted_msg)?;
-        mac.take().finalize().into()
-    };
+    // let (enc_key, mut mac) = kdf_msgkdf(&bx, node_pubkey, &my_public, verification)?;
 
-    let mut message = Vec::new();
-    message.write(&node_pubkey.id)?;
-    message.write(&node_pubkey.pk.as_bytes())?;
-    message.write(&my_public.as_bytes())?;
-    message.write(&encrypted_msg)?;
-    message.write(&msg_mac)?;
-    // --------
+    // // encrypted_msg = ENC(ENC_K1, CM)
+    // // msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
+    // let encrypted_msg = encrypt(&enc_key, client_msg);
+    // let msg_mac: DigestVal = {
+    //     use digest::Digest;
+    //     mac.write(&encrypted_msg)?;
+    //     mac.take().finalize().into()
+    // };
 
-    let mut buf = BytesMut::with_capacity(MAX_HANDSHAKE_LENGTH);
-    let mut hmac_key = materials.node_pubkey.pk.as_bytes().to_vec();
-    hmac_key.append(&mut materials.node_pubkey.id.as_bytes().to_vec());
-    client_msg.marshall(&mut buf, &hmac_key[..]);
-    let message = buf.to_vec();
+    // let mut message = Vec::new();
+    // message.write(&node_pubkey.id)?;
+    // message.write(&node_pubkey.pk.as_bytes())?;
+    // message.write(&my_public.as_bytes())?;
+    // message.write(&encrypted_msg)?;
+    // message.write(&msg_mac)?;
+    // // --------
 
-    let state = HandshakeState {
-        materials,
-        my_sk,
-        shared_secret: bx,
-        msg_mac,
-        epoch_hr: client_msg.get_epoch_hr(),
-    };
+    // let mut buf = BytesMut::with_capacity(MAX_HANDSHAKE_LENGTH);
+    // let mut hmac_key = materials.node_pubkey.pk.as_bytes().to_vec();
+    // hmac_key.append(&mut materials.node_pubkey.id.as_bytes().to_vec());
+    // client_msg.marshall(&mut buf, &hmac_key[..]);
+    // let message = buf.to_vec();
 
-    Ok((state, message))
+    // let state = HandshakeState {
+    //     materials,
+    //     my_sk,
+    //     shared_secret: bx,
+    //     msg_mac,
+    //     epoch_hr: client_msg.get_epoch_hr(),
+    // };
+
+    // Ok((state, message))
 }
 
 /// Finalize the handshake on the client side.
@@ -221,72 +243,74 @@ pub(crate) fn client_handshake_ntor_v3_part2(
     relay_handshake: &[u8],
     verification: &[u8],
 ) -> Result<(Vec<u8>, NtorV3XofReader)> {
-    let mut reader = Reader::from_slice(relay_handshake);
-    let y_pk: SessionPublicKey = reader
-        .extract()
-        .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    let auth: DigestVal = reader
-        .extract()
-        .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
-    let encrypted_msg = reader.into_rest();
-    let my_public = SessionPublicKey::from(&state.my_sk);
+    todo!("client handshake part 2");
 
-    // TODO: Some of this code is duplicated from the server handshake code!  It
-    // would be better to factor it out.
-    let yx = state.my_sk.diffie_hellman(&y_pk);
-    let secret_input = {
-        let mut si = SecretBuf::new();
-        si.write(&yx)
-            .and_then(|_| si.write(&state.shared_secret.as_bytes()))
-            .and_then(|_| si.write(&state.node_id()))
-            .and_then(|_| si.write(&state.node_pubkey().as_bytes()))
-            .and_then(|_| si.write(&my_public.as_bytes()))
-            .and_then(|_| si.write(&y_pk.as_bytes()))
-            .and_then(|_| si.write(PROTOID))
-            .and_then(|_| si.write(&Encap(verification)))
-            .map_err(into_internal!("error encoding ntor3 secret_input"))?;
-        si
-    };
-    let ntor_key_seed = h_key_seed(&secret_input);
-    let verify = h_verify(&secret_input);
+    // let mut reader = Reader::from_slice(relay_handshake);
+    // let y_pk: SessionPublicKey = reader
+    //     .extract()
+    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
+    // let auth: DigestVal = reader
+    //     .extract()
+    //     .map_err(|e| Error::from_bytes_err(e, "v3 ntor handshake"))?;
+    // let encrypted_msg = reader.into_rest();
+    // let my_public = SessionPublicKey::from(&state.my_sk);
 
-    let computed_auth: DigestVal = {
-        use digest::Digest;
-        let mut auth = DigestWriter(Sha3_256::default());
-        auth.write(&T_AUTH)
-            .and_then(|_| auth.write(&verify))
-            .and_then(|_| auth.write(&state.node_id()))
-            .and_then(|_| auth.write(&state.node_pubkey().as_bytes()))
-            .and_then(|_| auth.write(&y_pk.as_bytes()))
-            .and_then(|_| auth.write(&my_public.as_bytes()))
-            .and_then(|_| auth.write(&state.msg_mac))
-            .and_then(|_| auth.write(&Encap(encrypted_msg)))
-            .and_then(|_| auth.write(PROTOID))
-            .and_then(|_| auth.write(&b"Server"[..]))
-            .map_err(into_internal!("error encoding ntor3 authentication input"))?;
-        auth.take().finalize().into()
-    };
+    // // TODO: Some of this code is duplicated from the server handshake code!  It
+    // // would be better to factor it out.
+    // let yx = state.my_sk.diffie_hellman(&y_pk);
+    // let secret_input = {
+    //     let mut si = SecretBuf::new();
+    //     si.write(&yx)
+    //         .and_then(|_| si.write(&state.shared_secret.as_bytes()))
+    //         .and_then(|_| si.write(&state.node_id()))
+    //         .and_then(|_| si.write(&state.node_pubkey().as_bytes()))
+    //         .and_then(|_| si.write(&my_public.as_bytes()))
+    //         .and_then(|_| si.write(&y_pk.as_bytes()))
+    //         .and_then(|_| si.write(PROTOID))
+    //         .and_then(|_| si.write(&Encap(verification)))
+    //         .map_err(into_internal!("error encoding ntor3 secret_input"))?;
+    //     si
+    // };
+    // let ntor_key_seed = h_key_seed(&secret_input);
+    // let verify = h_verify(&secret_input);
 
-    let okay = computed_auth.ct_eq(&auth)
-        & ct::bool_to_choice(yx.was_contributory())
-        & ct::bool_to_choice(state.shared_secret.was_contributory());
+    // let computed_auth: DigestVal = {
+    //     use digest::Digest;
+    //     let mut auth = DigestWriter(Sha3_256::default());
+    //     auth.write(&T_AUTH)
+    //         .and_then(|_| auth.write(&verify))
+    //         .and_then(|_| auth.write(&state.node_id()))
+    //         .and_then(|_| auth.write(&state.node_pubkey().as_bytes()))
+    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&my_public.as_bytes()))
+    //         .and_then(|_| auth.write(&state.msg_mac))
+    //         .and_then(|_| auth.write(&Encap(encrypted_msg)))
+    //         .and_then(|_| auth.write(PROTOID))
+    //         .and_then(|_| auth.write(&b"Server"[..]))
+    //         .map_err(into_internal!("error encoding ntor3 authentication input"))?;
+    //     auth.take().finalize().into()
+    // };
 
-    let (enc_key, keystream) = {
-        use digest::{ExtendableOutput, XofReader};
-        let mut xof = DigestWriter(Shake256::default());
-        xof.write(&T_FINAL)
-            .and_then(|_| xof.write(&ntor_key_seed))
-            .map_err(into_internal!("error encoding ntor3 xof input"))?;
-        let mut r = xof.take().finalize_xof();
-        let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-        r.read(&mut enc_key[..]);
-        (enc_key, r)
-    };
-    let server_reply = decrypt(&enc_key, encrypted_msg);
+    // let okay = computed_auth.ct_eq(&auth)
+    //     & ct::bool_to_choice(yx.was_contributory())
+    //     & ct::bool_to_choice(state.shared_secret.was_contributory());
 
-    if okay.into() {
-        Ok((server_reply, NtorV3XofReader::new(keystream)))
-    } else {
-        Err(Error::BadCircHandshakeAuth)
-    }
+    // let (enc_key, keystream) = {
+    //     use digest::{ExtendableOutput, XofReader};
+    //     let mut xof = DigestWriter(Shake256::default());
+    //     xof.write(&T_FINAL)
+    //         .and_then(|_| xof.write(&ntor_key_seed))
+    //         .map_err(into_internal!("error encoding ntor3 xof input"))?;
+    //     let mut r = xof.take().finalize_xof();
+    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
+    //     r.read(&mut enc_key[..]);
+    //     (enc_key, r)
+    // };
+    // let server_reply = decrypt(&enc_key, encrypted_msg);
+
+    // if okay.into() {
+    //     Ok((server_reply, NtorV3XofReader::new(keystream)))
+    // } else {
+    //     Err(Error::BadCircHandshakeAuth)
+    // }
 }

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -153,7 +153,7 @@ impl<K: OKemCore> ClientHandshake for NtorV3Client<K> {
     /// client onionskin that the server is replying to.
     fn client2<T: AsRef<[u8]>>(state: &mut Self::StateType, msg: T) -> Result<Self::HsOutput> {
         let (message, xof_reader) =
-            client_handshake_ntor_v3_part2::<K>(&state, msg.as_ref(), NTOR3_CIRC_VERIFICATION)?;
+            client_handshake_ntor_v3_part2::<K>(state, msg.as_ref(), NTOR3_CIRC_VERIFICATION)?;
         let extensions = NtorV3Extension::decode(&message).map_err(|err| Error::CellDecodeErr {
             object: "ntor v3 extensions",
             err,

--- a/crates/o5/src/handshake/client.rs
+++ b/crates/o5/src/handshake/client.rs
@@ -4,7 +4,7 @@ use crate::{
         ntor_arti::{
             ClientHandshake, ClientHandshakeComplete, ClientHandshakeMaterials, KeyGenerator,
         },
-        xwing::SharedSecret,
+        xwing::{DecapsulationKey, SharedSecret},
     },
     constants::*,
     framing::handshake::ClientHandshakeMessage,
@@ -53,8 +53,8 @@ pub(crate) struct HandshakeState {
 }
 
 impl HandshakeState {
-    fn node_pubkey(&self) -> &xwing::PublicKey {
-        &self.materials.node_pubkey.pk
+    fn node_pubkey(&self) -> &xwing::EncapsulationKey {
+        &self.materials.node_pubkey.ek
     }
 
     fn node_id(&self) -> Ed25519Identity {
@@ -174,8 +174,8 @@ pub(crate) fn client_handshake_ntor_v3<R: RngCore + CryptoRng>(
     materials: HandshakeMaterials,
     verification: &[u8],
 ) -> EncodeResult<(HandshakeState, Vec<u8>)> {
-    let my_sk = SessionSecretKey::random_from_rng(rng);
-    client_handshake_ntor_v3_no_keygen(my_sk, materials, verification)
+    let (dk_session, _ek_session) = xwing::generate_key_pair(rng);
+    client_handshake_ntor_v3_no_keygen(dk_session, materials, verification)
 }
 
 /// As `client_handshake_ntor_v3`, but don't generate an ephemeral DH

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -13,8 +13,10 @@ use base64::{
     engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
     Engine,
 };
+use hybrid_array::Array;
 use kem::{Decapsulate, Encapsulate};
 use kemeleon::{Encode, MlKem768, OKemCore};
+use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConstantTimeEq};
 use tor_bytes::{EncodeResult, Readable, SecretBuf, Writeable, Writer};
 use tor_llcrypto::{
@@ -22,8 +24,6 @@ use tor_llcrypto::{
     pk::ed25519::{Ed25519Identity, ED25519_ID_LEN},
 };
 use typenum::Unsigned;
-
-use rand::{CryptoRng, RngCore};
 
 /// Ephemeral single use session secret key type
 pub struct EphemeralKey<K: OKemCore>(<K as OKemCore>::DecapsulationKey);
@@ -113,7 +113,7 @@ impl<K: OKemCore> Clone for IdentityPublicKey<K> {
     fn clone(&self) -> Self {
         Self {
             id: self.id.clone(),
-            ek: <K as OKemCore>::EncapsulationKey::from(&self.ek),
+            ek: <K as OKemCore>::EncapsulationKey::from(self.ek.clone()),
         }
     }
 }

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -205,7 +205,7 @@ impl KeyGenerator for NtorV3KeyGenerator {
 impl NtorV3KeyGen for NtorV3KeyGenerator {}
 
 impl NtorV3KeyGenerator {
-    pub(crate) fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
+    pub fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
         // let okm = Self::kdf(&seed[..], KEY_MATERIAL_LENGTH * 2 + SESSION_ID_LEN)
         //     .expect("bug: failed to derive key material from seed");
 

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -171,6 +171,7 @@ impl Into<xwing::PublicKey> for &IdentitySecretKey {
 pub trait NtorV3KeyGen: KeyGenerator + SessionIdentifier + Into<O5Codec> {}
 
 /// Opaque wrapper type for NtorV3's hash reader.
+#[derive(Clone)]
 pub(crate) struct NtorV3XofReader(Shake256Reader);
 
 impl NtorV3XofReader {
@@ -249,9 +250,9 @@ impl KeyGenerator for NtorV3XofReader {
     }
 }
 
-impl From<NtorV3KeyGenerator> for O5Codec {
-    fn from(keygen: NtorV3KeyGenerator) -> Self {
-        keygen.codec
+impl<K: NtorV3KeyGen> From<K> for O5Codec {
+    fn from(value: K) -> Self {
+        value.into()
     }
 }
 

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -112,7 +112,7 @@ pub struct IdentityPublicKey<K: OKemCore> {
 impl<K: OKemCore> Clone for IdentityPublicKey<K> {
     fn clone(&self) -> Self {
         Self {
-            id: self.id.clone(),
+            id: self.id,
             ek: <K as OKemCore>::EncapsulationKey::from(self.ek.clone()),
         }
     }
@@ -302,10 +302,16 @@ impl KeyGenerator for NtorV3KeyGenerator {
     }
 }
 
+impl From<NtorV3KeyGenerator> for O5Codec {
+    fn from(val: NtorV3KeyGenerator) -> Self {
+        val.codec
+    }
+}
+
 impl NtorV3KeyGen for NtorV3KeyGenerator {}
 
 impl NtorV3KeyGenerator {
-    pub fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
+    pub(crate) fn new<R: Role>(mut reader: NtorV3XofReader) -> Self {
         // let okm = Self::kdf(&seed[..], KEY_MATERIAL_LENGTH * 2 + SESSION_ID_LEN)
         //     .expect("bug: failed to derive key material from seed");
 
@@ -347,12 +353,6 @@ impl KeyGenerator for NtorV3XofReader {
         let mut ret: SecretBuf = vec![0; keylen].into();
         self.0.read(ret.as_mut());
         Ok(ret)
-    }
-}
-
-impl<K: NtorV3KeyGen> From<K> for O5Codec {
-    fn from(value: K) -> Self {
-        value.into()
     }
 }
 

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -13,27 +13,82 @@ use base64::{
     engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
     Engine,
 };
-use kem::Encapsulate;
-use kemeleon::{MlKem768, OKemCore, Encode};
+use kem::{Decapsulate, Encapsulate};
+use kemeleon::{Encode, MlKem768, OKemCore};
 use subtle::{Choice, ConstantTimeEq};
-use tor_bytes::{Readable, SecretBuf, Writeable, Writer, EncodeResult};
-use tor_llcrypto::{d::Shake256Reader, pk::ed25519::Ed25519Identity};
+use tor_bytes::{EncodeResult, Readable, SecretBuf, Writeable, Writer};
+use tor_llcrypto::{
+    d::Shake256Reader,
+    pk::ed25519::{Ed25519Identity, ED25519_ID_LEN},
+};
+use typenum::Unsigned;
 
 use rand::{CryptoRng, RngCore};
 
 /// Ephemeral single use session secret key type
-pub type EphemeralKey<K> = <K as OKemCore>::DecapsulationKey;
+pub struct EphemeralKey<K: OKemCore>(<K as OKemCore>::DecapsulationKey);
+
+impl<K: OKemCore> EphemeralKey<K> {
+    pub fn new(inner: K::DecapsulationKey) -> Self {
+        Self(inner)
+    }
+}
+
+impl<K: OKemCore> Decapsulate<K::Ciphertext, K::SharedKey> for EphemeralKey<K> {
+    type Error = <K::DecapsulationKey as Decapsulate<K::Ciphertext, K::SharedKey>>::Error;
+
+    fn decapsulate(
+        &self,
+        encapsulated_key: &K::Ciphertext,
+    ) -> std::result::Result<K::SharedKey, Self::Error> {
+        self.0.decapsulate(encapsulated_key)
+    }
+}
 
 /// Public key type associated with EphemeralKey.
-pub type EphemeralPub<K> = <K as OKemCore>::EncapsulationKey;
+#[derive(Clone)]
+pub struct EphemeralPub<K: OKemCore>(<K as OKemCore>::EncapsulationKey);
 
-impl<K:OKemCore> Readable for EphemeralPub<K> {
+impl<K: OKemCore> EphemeralPub<K> {
+    pub fn new(inner: K::EncapsulationKey) -> Self {
+        Self(inner)
+    }
+}
+
+impl<K: OKemCore> Encapsulate<K::Ciphertext, K::SharedKey> for EphemeralPub<K> {
+    type Error = <K::EncapsulationKey as Encapsulate<K::Ciphertext, K::SharedKey>>::Error;
+
+    fn encapsulate(
+        &self,
+        rng: &mut impl rand_core::CryptoRngCore,
+    ) -> std::result::Result<(K::Ciphertext, K::SharedKey), Self::Error> {
+        self.0.encapsulate(rng)
+    }
+}
+
+impl<K: OKemCore> Encode for EphemeralPub<K> {
+    type Error = <K::EncapsulationKey as Encode>::Error;
+    type EncodedSize = <K::EncapsulationKey as Encode>::EncodedSize;
+
+    fn as_bytes(&self) -> ml_kem::array::Array<u8, Self::EncodedSize> {
+        self.0.as_bytes()
+    }
+
+    fn try_from_bytes<B: AsRef<[u8]>>(buf: B) -> std::result::Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
+        Ok(Self(<K::EncapsulationKey as Encode>::try_from_bytes(buf)?))
+    }
+}
+
+impl<K: OKemCore> Readable for EphemeralPub<K> {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {
         todo!("Session Public Key `EphemeralPub<K>` Reader needs implemented");
     }
 }
 
-impl<K:OKemCore> Writeable for EphemeralPub<K> {
+impl<K: OKemCore> Writeable for EphemeralPub<K> {
     fn write_onto<B: Writer + ?Sized>(&self, b: &mut B) -> EncodeResult<()> {
         todo!("Session Public Key `EphemeralPub<K>` Writer needs implemented");
     }
@@ -46,35 +101,67 @@ pub type IdentityPub = IdentityPublicKey<MlKem768>;
 ///
 /// Contains a single curve25519 ntor onion key, and the relay's ed25519
 /// identity.
-#[derive(Clone, Debug, PartialEq)]
-pub struct IdentityPublicKey<K:OKemCore> {
+#[derive(PartialEq)]
+pub struct IdentityPublicKey<K: OKemCore> {
     /// The relay's identity.
     pub(crate) id: Ed25519Identity,
     /// The relay's onion key.
     pub(crate) ek: <K as OKemCore>::EncapsulationKey,
 }
 
-impl<K:OKemCore> From<&IdentitySecretKey<K>> for IdentityPublicKey<K> {
+impl<K: OKemCore> Clone for IdentityPublicKey<K> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id.clone(),
+            ek: <K as OKemCore>::EncapsulationKey::from(&self.ek),
+        }
+    }
+}
+
+impl<K: OKemCore> core::fmt::Debug for IdentityPublicKey<K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IdentityPublicKey")
+            .field("id", &self.id)
+            .field("pk", &hex::encode(&self.ek.as_bytes()[0..16]))
+            .finish()
+    }
+}
+
+impl<K: OKemCore> From<&IdentitySecretKey<K>> for IdentityPublicKey<K> {
     fn from(value: &IdentitySecretKey<K>) -> Self {
         value.pk.clone()
     }
 }
 
-impl<K:OKemCore> IdentityPublicKey<K> {
-    const CERT_LENGTH: usize = xwing::PUBKEY_LEN;
+impl<K: OKemCore> IdentityPublicKey<K> {
+    const CERT_LENGTH: usize = <K::EncapsulationKey as Encode>::EncodedSize::USIZE + ED25519_ID_LEN;
     const CERT_SUFFIX: &'static str = "==";
+
     /// Construct a new IdentityPublicKey from its components.
     #[allow(unused)]
     pub(crate) fn new(ek_bytes: impl AsRef<[u8]>, id: [u8; NODE_ID_LENGTH]) -> Result<Self> {
-        let ek =  K::EncapsulationKey::try_from_bytes(ek_bytes).map_err(|e| Error::other(Box::new(e)))?;
-        Ok(Self {
-            ek,
-            id: id.into(),
-        })
+        let ek = K::EncapsulationKey::try_from_bytes(ek_bytes)
+            .map_err(|_| Error::other("failed to parse Identity Key"))?;
+        Ok(Self { ek, id: id.into() })
+    }
+
+    pub fn try_from_bytes(buf: impl AsRef<[u8]>) -> std::result::Result<Self, Error> {
+        let arr = buf.as_ref();
+        if arr.len() < Self::CERT_LENGTH {
+            return Err(Error::other(
+                "provided identity key is improperly formatted -- too short",
+            ));
+        }
+        let id: [u8; NODE_ID_LENGTH] = arr[..ED25519_ID_LEN].try_into()?;
+        let ek =
+            Array::<u8, <<K as OKemCore>::EncapsulationKey as Encode>::EncodedSize>::from_fn(|i| {
+                arr[ED25519_ID_LEN + i]
+            });
+        IdentityPublicKey::new(ek, id)
     }
 }
 
-impl<K:OKemCore> std::str::FromStr for IdentityPublicKey<K> {
+impl<K: OKemCore> std::str::FromStr for IdentityPublicKey<K> {
     type Err = Error;
     fn from_str(s: &str) -> std::prelude::v1::Result<Self, Self::Err> {
         let mut cert = String::from(s);
@@ -92,7 +179,7 @@ impl<K:OKemCore> std::str::FromStr for IdentityPublicKey<K> {
 }
 
 #[allow(clippy::to_string_trait_impl)]
-impl<K:OKemCore> std::string::ToString for IdentityPublicKey<K> {
+impl<K: OKemCore> std::string::ToString for IdentityPublicKey<K> {
     fn to_string(&self) -> String {
         let mut s = Vec::from(self.id.as_bytes());
         s.extend(self.ek.as_bytes());
@@ -100,28 +187,28 @@ impl<K:OKemCore> std::string::ToString for IdentityPublicKey<K> {
     }
 }
 
-impl<K:OKemCore> Readable for IdentityPublicKey<K> {
+impl<K: OKemCore> Readable for IdentityPublicKey<K> {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {
         todo!("IdentityPublicKey Reader needs implemented");
     }
 }
 
 /// Secret key information used by a relay for the ntor v3 handshake.
-pub struct IdentitySecretKey<K: OKemCore>{
+pub struct IdentitySecretKey<K: OKemCore> {
     /// The relay's public key information
     pub(crate) pk: IdentityPublicKey<K>,
     /// The secret onion key.
     pub(super) sk: <K as OKemCore>::DecapsulationKey,
 }
 
-impl<K:OKemCore> IdentitySecretKey<K> {
+impl<K: OKemCore> IdentitySecretKey<K> {
     /// Construct a new IdentitySecretKey from its components.
     #[allow(unused)]
     pub(crate) fn new(sk: <K as OKemCore>::DecapsulationKey, id: Ed25519Identity) -> Self {
         Self {
             pk: IdentityPublicKey {
                 id,
-                ek: sk.encapsulation_key(),
+                ek: K::encapsulation_key(&sk),
             },
             sk,
         }
@@ -135,7 +222,8 @@ impl<K:OKemCore> IdentitySecretKey<K> {
 
         let mut id = [0u8; NODE_ID_LENGTH];
         id.copy_from_slice(&buf[..NODE_ID_LENGTH]);
-        let sk = K::DecapsulationKey::try_from_bytes(&buf[NODE_ID_LENGTH..])?;
+        let sk = K::DecapsulationKey::try_from_bytes(&buf[NODE_ID_LENGTH..])
+            .map_err(|_| Error::other("failed to parse decapsulation key"))?;
         Ok(Self::new(sk, id.into()))
     }
 
@@ -152,12 +240,16 @@ impl<K:OKemCore> IdentitySecretKey<K> {
     /// Checks whether `id` and `pk` match this secret key.
     ///
     /// Used to perform a constant-time secret key lookup.
-    pub(crate) fn matches(&self, id: Ed25519Identity, ek: <K as OKemCore>::EncapsulationKey) -> Choice {
+    pub(crate) fn matches(
+        &self,
+        id: Ed25519Identity,
+        ek: <K as OKemCore>::EncapsulationKey,
+    ) -> Choice {
         id.as_bytes().ct_eq(self.pk.id.as_bytes()) & ek.as_bytes().ct_eq(&self.pk.ek.as_bytes()[..])
     }
 }
 
-impl<K:OKemCore> TryFrom<&[u8]> for IdentitySecretKey<K> {
+impl<K: OKemCore> TryFrom<&[u8]> for IdentitySecretKey<K> {
     type Error = Error;
     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
         Self::try_from_bytes(value)

--- a/crates/o5/src/handshake/keys.rs
+++ b/crates/o5/src/handshake/keys.rs
@@ -187,7 +187,7 @@ impl digest::XofReader for NtorV3XofReader {
 }
 
 /// A key generator returned from an ntor v3 handshake.
-pub(crate) struct NtorV3KeyGenerator {
+pub struct NtorV3KeyGenerator {
     /// The underlying `digest::XofReader`.
     reader: NtorV3XofReader,
     session_id: SessionID,

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -2,28 +2,41 @@ use crate::{
     common::{
         ct,
         drbg::SEED_LENGTH,
-        ntor_arti::{AuxDataReply, RelayHandshakeError, RelayHandshakeResult, ServerHandshake},
+        ntor_arti::{self, AuxDataReply, RelayHandshakeError, RelayHandshakeResult},
+        utils::{find_mac_mark, get_epoch_hour},
     },
+    constants::*,
+    framing::{
+        ClientHandshakeMessage, ClientStateIncoming, ClientStateOutgoing, ServerHandshakeMessage,
+        ServerStateOutgoing,
+    },
+    handshake::client::NtorV3Client as Client,
     handshake::*,
-    Error, Server,
+    traits::{DigestSizes, FramingSizes, OKemCore},
+    Digest, Error, Result, Server,
 };
 
-// use cipher::KeyIvInit;
-use digest::{Digest, ExtendableOutput, XofReader};
-use hmac::{Hmac, Mac};
-use kemeleon::OKemCore;
+use std::time::Instant;
+
+use bytes::BufMut;
+use digest::{Digest as _, ExtendableOutput as _};
+use hmac::{Mac, SimpleHmac};
+use kem::{Decapsulate, Encapsulate};
 use keys::NtorV3KeyGenerator;
-use rand_core::{CryptoRng, RngCore};
-use sha2::Sha256;
+use ptrs::{debug, trace};
+use rand::Rng;
+use rand_core::{CryptoRng, CryptoRngCore, RngCore};
+use sha3::Shake256;
 use subtle::ConstantTimeEq;
 use tor_bytes::{Reader, SecretBuf, Writer};
 use tor_cell::relaycell::extend::NtorV3Extension;
 use tor_error::into_internal;
-use tor_llcrypto::d::{Sha3_256, Shake256};
 use tor_llcrypto::pk::ed25519::Ed25519Identity;
+use typenum::Unsigned;
 use zeroize::Zeroizing;
 
 /// Server Materials needed for completing a handshake
+#[derive(Clone, Debug)]
 pub(crate) struct HandshakeMaterials {
     pub(crate) session_id: String,
     pub(crate) len_seed: [u8; SEED_LENGTH],
@@ -38,18 +51,31 @@ impl HandshakeMaterials {
     }
 }
 
-impl ServerHandshake for Server {
-    type HandshakeParams = SHSMaterials;
+pub(crate) struct ServerHandshake<K: OKemCore, D: Digest> {
+    pub(crate) materials: HandshakeMaterials,
+    pub(crate) server: Server<K, D>,
+}
+
+impl<K: OKemCore, D: Digest> ServerHandshake<K, D> {
+    pub(crate) fn new(server: Server<K, D>, materials: HandshakeMaterials) -> Self {
+        Self {
+            materials,
+            server: server.clone(),
+        }
+    }
+}
+
+impl<K: OKemCore, D: Digest> ntor_arti::ServerHandshake for ServerHandshake<K, D> {
     type KeyGen = NtorV3KeyGenerator;
     type ClientAuxData = [NtorV3Extension];
     type ServerAuxData = Vec<NtorV3Extension>;
 
-    fn server<REPLY: AuxDataReply<Self>, T: AsRef<[u8]>>(
+    fn server<REPLY: AuxDataReply<Self>, T: AsRef<[u8]>, Out: BufMut>(
         &self,
         reply_fn: &mut REPLY,
-        _materials: &Self::HandshakeParams, // TODO: do we need materials during server handshake?
         msg: T,
-    ) -> RelayHandshakeResult<(Self::KeyGen, Vec<u8>)> {
+        reply_buf: &mut Out,
+    ) -> RelayHandshakeResult<Self::KeyGen> {
         let mut bytes_reply_fn = |bytes: &[u8]| -> Option<Vec<u8>> {
             let client_exts = NtorV3Extension::decode(bytes).ok()?;
             let reply_exts = reply_fn.reply(&client_exts)?;
@@ -59,165 +85,349 @@ impl ServerHandshake for Server {
         };
         let mut rng = rand::thread_rng();
 
-        let (res, reader) = server_handshake_ntor_v3(
-            &mut rng,
-            &mut bytes_reply_fn,
-            msg.as_ref(),
-            &self.identity_keys,
-            NTOR3_CIRC_VERIFICATION,
-        )?;
-        Ok((NtorV3KeyGenerator::new::<ServerRole>(reader), res))
+        let (response, reader) =
+            self.handshake_ntor_v3(&mut rng, &mut bytes_reply_fn, msg.as_ref())?;
+
+        response.marshall(&mut rng, reply_buf);
+
+        Ok(NtorV3KeyGenerator::new::<ServerRole>(reader))
     }
 }
 
-/// Complete an ntor v3 handshake as a server.
-///
-/// Use the provided `rng` to generate keys; use the provided
-/// `reply_fn` to handle incoming client secret message and decide how
-/// to reply.  The client's handshake is in `message`.  Our private
-/// key(s) are in `keys`.  The `verification` string must match the
-/// string provided by the client.
-///
-/// On success, return the server handshake message to send, and an XofReader
-/// to use in generating circuit keys.
-pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply, K: OKemCore>(
-    rng: &mut R,
-    reply_fn: &mut REPLY,
-    message: &[u8],
-    keys: &IdentitySecretKey<K>,
-    verification: &[u8],
-) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    let (dk_session, _ek_session) = K::generate(rng);
-    let ephemeral_dk = EphemeralKey::new(dk_session);
-    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &ephemeral_dk, message, keys, verification)
-}
+impl<K: OKemCore, D: Digest> ServerHandshake<K, D> {
+    /// Complete an ntor v3 handshake as a server.
+    ///
+    ///    shared_secret_1 = Decapsulate(DKs, ct)
+    ///
+    ///    CTs, shared_secret_2 = Encapsulate(EKc)
+    ///
+    ///    ES = F2(NodeID, shared_secret_1)
+    ///    ES' = F1(ES, ":derive_key")
+    ///    FS = F2(ES', shared_secret_2)
+    ///    context = CTco | EKco | EKso | CTso
+    ///
+    ///    SESSION_KEY = F1(FS, context | PROTOID | ":key_extract")
+    ///
+    /// On success, return the server handshake message to send, and the session keys
+    pub(crate) fn handshake_ntor_v3<'a>(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        reply_fn: &mut impl MsgReply,
+        message: &'a [u8],
+    ) -> RelayHandshakeResult<(
+        ServerHandshakeMessage<K, D, ServerStateOutgoing<D>>,
+        NtorV3XofReader,
+    )> {
+        self.handshake_ntor_v3_no_keygen(rng, reply_fn, message)
+    }
 
-/// As `server_handshake_ntor_v3`, but take a secret key instead of an RNG.
-pub(crate) fn server_handshake_ntor_v3_no_keygen<
-    R: CryptoRng + RngCore,
-    REPLY: MsgReply,
-    K: OKemCore,
->(
-    rng: &mut R,
-    reply_fn: &mut REPLY,
-    secret_key_y: &EphemeralKey<K>,
-    message: &[u8],
-    keys: &IdentitySecretKey<K>,
-    verification: &[u8],
-) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    todo!("server handshake");
+    /// As `server_handshake_ntor_v3`, but take a secret key instead of an RNG.
+    pub(crate) fn handshake_ntor_v3_no_keygen<'a>(
+        &self,
+        rng: &mut impl CryptoRngCore,
+        extension_handle: &mut impl MsgReply,
+        msg: &'a [u8],
+    ) -> RelayHandshakeResult<(
+        ServerHandshakeMessage<K, D, ServerStateOutgoing<D>>,
+        NtorV3XofReader,
+    )> {
+        // let msg = message.as_ref();
+        if Client::<K, D>::CLIENT_MIN_HANDSHAKE_LENGTH > msg.len() {
+            Err(RelayHandshakeError::EAgain)?;
+        }
 
-    // // Decode the message.
-    // let mut r = Reader::from_slice(message);
-    // let id: Ed25519Identity = r.extract()?;
-    // let requested_pk: IdentityPublicKey<K> = r.extract()?;
-    // let client_pk: SessionPublicKey = r.extract()?;
-    // let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
-    //     r.take(msg_len)?
-    // } else {
-    //     let deficit = (MAC_LEN - r.remaining())
-    //         .try_into()
-    //         .expect("miscalculated!");
-    //     return Err(Error::incomplete_error(deficit).into());
-    // };
+        let mut client_hs = match self.try_parse_client_handshake(msg, &self.materials) {
+            Ok(chs) => chs,
+            Err(RelayHandshakeError::EAgain) => {
+                return Err(RelayHandshakeError::EAgain);
+            }
+            Err(_e) => {
+                debug!(
+                    "{} failed to parse client handshake: {_e}",
+                    self.materials.session_id
+                );
+                return Err(RelayHandshakeError::BadClientHandshake);
+            }
+        };
 
-    // let msg_mac: MessageMac = r.extract()?;
-    // r.should_be_exhausted()?;
+        debug!(
+            "{} successfully parsed client handshake",
+            self.materials.session_id
+        );
+        let client_session_ek = client_hs.get_public();
+        let ephemeral_secret = client_hs.get_ephemeral_secret();
 
-    // // See if we recognize the provided (id,requested_pk) pair.
-    // let keypair = match keys.matches(id, requested_pk.pk).into() {
-    //     Some(k) => keys,
-    //     None => return Err(RelayHandshakeError::MissingKey),
-    // };
+        // Create the server side KEM challenge.
+        let (ciphertext, shared_secret_2) = client_session_ek
+            .encapsulate(rng)
+            .map_err(|_| RelayHandshakeError::FailedEncapsulation)?;
 
-    // let xb = keypair
-    //     .hpke(rng, &client_pk)
-    //     .map_err(|e| Error::Crypto(e.into()))?;
-    // let (enc_key, mut mac) = kdf_msgkdf(&xb, &keypair.pk, &client_pk, verification)
-    //     .map_err(into_internal!("Can't apply ntor3 kdf."))?;
-    // // Verify the message we received.
-    // let computed_mac: DigestVal = {
-    //     mac.write(client_msg)
-    //         .map_err(into_internal!("Can't compute MAC input."))?;
-    //     mac.take().finalize().into()
-    // };
-    // let y_pk = SessionPublicKey::from(secret_key_y);
-    // let xy = secret_key_y.hpke(rng, &client_pk)?;
+        let mut f1_es = SimpleHmac::<D>::new_from_slice(ephemeral_secret.as_ref())
+            .expect("keying hmac should never fail");
 
-    // let mut okay = computed_mac.ct_eq(&msg_mac)
-    //     & ct::bool_to_choice(xy.was_contributory())
-    //     & ct::bool_to_choice(xb.was_contributory());
+        // compute the Session Ephemeral Secret
+        let derivation_ephemeral = {
+            f1_es.reset();
+            f1_es.update(&KEY_DERIVE_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
 
-    // let plaintext_msg = decrypt(&enc_key, client_msg);
+        let mut f2 = SimpleHmac::<D>::new_from_slice(derivation_ephemeral.as_ref())
+            .expect("keying hmac should never fail");
 
-    // // Handle the message and decide how to reply.
-    // let reply = reply_fn.reply(&plaintext_msg);
+        // compute our Combiner Ephemeral Secret
+        let combiner_ephemeral = {
+            f2.reset();
+            f2.update(&shared_secret_2.as_bytes()[..]);
+            Zeroizing::new(f2.finalize_reset().into_bytes())
+        };
 
-    // // It's not exactly constant time to use is_some() and
-    // // unwrap_or_else() here, but that should be somewhat
-    // // hidden by the rest of the computation.
-    // okay &= ct::bool_to_choice(reply.is_some());
-    // let reply = reply.unwrap_or_default();
+        // Handshake context = EKco || CTco || EKso || CTso || protocol_id
+        let mut context = {
+            let mut c = SecretBuf::new();
+            c.write(&msg[K::EK_SIZE..K::EK_SIZE + K::CT_SIZE]) // EKco || CTco from client handshake
+                .and_then(|_| c.write(&self.server.get_identity().ek.as_bytes()[..])) // EKso server identity key
+                .and_then(|_| c.write(&ciphertext.as_bytes()[..])) // CTso server created ciphertext
+                .and_then(|_| c.write(Server::<K, D>::protocol_id().as_bytes())) // protocol ID
+                .map_err(|_| {
+                    RelayHandshakeError::FrameError("failed to wire reply context".into())
+                })?;
+            c
+        };
 
-    // // If we reach this point, we are actually replying, or pretending
-    // // that we're going to reply.
+        let mut f1_fs = SimpleHmac::<D>::new_from_slice(combiner_ephemeral.as_ref())
+            .expect("keying hmac should never fail");
 
-    // let secret_input = {
-    //     let mut si = SecretBuf::new();
-    //     si.write(&xy.as_bytes())
-    //         .and_then(|_| si.write(&xb.as_bytes()))
-    //         .and_then(|_| si.write(&keypair.pk.id))
-    //         .and_then(|_| si.write(&keypair.pk.pk.as_bytes()))
-    //         .and_then(|_| si.write(&client_pk.as_bytes()))
-    //         .and_then(|_| si.write(&y_pk.as_bytes()))
-    //         .and_then(|_| si.write(PROTOID))
-    //         .and_then(|_| si.write(&Encap(verification)))
-    //         .map_err(into_internal!("can't derive ntor3 secret_input"))?;
-    //     si
-    // };
-    // let ntor_key_seed = h_key_seed(&secret_input);
-    // let verify = h_verify(&secret_input);
+        // Compute the Session Key value used to key our cipher.
+        let session_key = {
+            f1_fs.reset();
+            f1_fs.update(&context[..]);
+            f1_fs.update(KEY_EXTRACT_ARG);
+            Zeroizing::new(f1_fs.finalize_reset().into_bytes())
+        };
 
-    // let (enc_key, keystream) = {
-    //     let mut xof = DigestWriter(Shake256::default());
-    //     xof.write(&T_FINAL)
-    //         .and_then(|_| xof.write(&ntor_key_seed))
-    //         .map_err(into_internal!("can't generate ntor3 xof."))?;
-    //     let mut r = xof.take().finalize_xof();
-    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-    //     r.read(&mut enc_key[..]);
-    //     (enc_key, r)
-    // };
-    // let encrypted_reply = encrypt(&enc_key, &reply);
-    // let auth: DigestVal = {
-    //     let mut auth = DigestWriter(Sha3_256::default());
-    //     auth.write(&T_AUTH)
-    //         .and_then(|_| auth.write(&verify))
-    //         .and_then(|_| auth.write(&keypair.pk.id))
-    //         .and_then(|_| auth.write(&keypair.pk.pk.as_bytes()))
-    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
-    //         .and_then(|_| auth.write(&client_pk.as_bytes()))
-    //         .and_then(|_| auth.write(&msg_mac))
-    //         .and_then(|_| auth.write(&Encap(&encrypted_reply)))
-    //         .and_then(|_| auth.write(PROTOID))
-    //         .and_then(|_| auth.write(&b"Server"[..]))
-    //         .map_err(into_internal!("can't derive ntor3 authentication"))?;
-    //     auth.take().finalize().into()
-    // };
+        // Compute the Server message authentication value
+        let auth = {
+            f1_fs.reset();
+            f1_fs.update(&context[..]);
+            f1_fs.update(SERVER_AUTH_ARG);
+            f1_fs.finalize_reset().into_bytes()
+        };
 
-    // let reply = {
-    //     let mut reply = Vec::new();
-    //     reply
-    //         .write(&y_pk.as_bytes())
-    //         .and_then(|_| reply.write(&auth))
-    //         .and_then(|_| reply.write(&encrypted_reply))
-    //         .map_err(into_internal!("can't encode ntor3 reply."))?;
-    //     reply
-    // };
+        let (enc_key, keystream) = {
+            use digest::{ExtendableOutput, Update, XofReader};
+            let mut xof = Shake256::default();
+            xof.update(&T_FINAL);
+            xof.update(&session_key);
+            let mut r = xof.finalize_xof();
+            let mut enc_key = SessionSharedSecret::<D>::default();
+            r.read(&mut enc_key[..]);
+            (enc_key, r)
+        };
 
-    // if okay.into() {
-    //     Ok((reply, NtorV3XofReader::new(keystream)))
-    // } else {
-    //     Err(RelayHandshakeError::BadClientHandshake)
-    // }
+        // Handle extension messages and (optionally) craft a reply.
+        let extensions_reply = extension_handle
+            .reply(&client_hs.get_extensions())
+            .unwrap_or_default();
+
+        let pad_len = rng.gen_range(MIN_PAD_LENGTH..Server::<K, D>::SERVER_MAX_PAD_LENGTH); // TODO - recalculate these
+
+        let state_outgoing = ServerStateOutgoing::<D> {
+            pad_len,
+            encrypted_extension_reply: encrypt::<D>(&enc_key, &extensions_reply),
+            ephemeral_secret,
+            hs_materials: &self.materials,
+        };
+        let server_hs_msg = ServerHandshakeMessage::<K, D, ServerStateOutgoing<D>>::new(
+            ciphertext,
+            auth,
+            state_outgoing,
+        );
+
+        Ok((server_hs_msg, NtorV3XofReader::new(keystream)))
+
+        // todo!("Add extensions and prng seed to the server hello");
+    }
+
+    fn try_parse_client_handshake(
+        &self,
+        b: impl AsRef<[u8]>,
+        materials: &HandshakeMaterials,
+    ) -> RelayHandshakeResult<ClientHandshakeMessage<K, ClientStateIncoming<D>>> {
+        let buf = b.as_ref();
+
+        if Client::<K, D>::CLIENT_MIN_HANDSHAKE_LENGTH > buf.len() {
+            Err(RelayHandshakeError::EAgain)?;
+        }
+
+        let server_identity_key = &self.server.identity_keys.sk;
+        trace!(
+            "id pubkey: {}",
+            hex::encode(&self.server.identity_keys.pk.ek.as_bytes()[..])
+        );
+
+        // get the chunk containing the clients encapsulation key
+        let mut client_ek_obfs = &buf[0..K::EK_SIZE];
+
+        // get the chunk containing the ciphertext
+        let mut client_ct_obfs = &buf[K::EK_SIZE..K::EK_SIZE + K::CT_SIZE];
+
+        // decode and decapsulate the secret encoded by the client
+        let client_ct = <K as kemeleon::OKemCore>::Ciphertext::try_from_bytes(&client_ct_obfs)
+            .map_err(|e| RelayHandshakeError::FailedParse)?;
+        let shared_secret = server_identity_key
+            .decapsulate(&client_ct)
+            .map_err(|e| RelayHandshakeError::FailedDecapsulation)?;
+        let shared_secret = &shared_secret.as_bytes()[..];
+
+        let node_id = self.server.get_identity().id;
+        let mut f2 = SimpleHmac::<D>::new_from_slice(node_id.as_bytes())
+            .expect("keying server f2 hmac should never fail");
+
+        // Compute the Ephemeral Secret
+        let ephemeral_secret = {
+            f2.reset();
+            f2.update(shared_secret);
+            Zeroizing::new(f2.finalize_reset().into_bytes())
+        };
+
+        trace!("shared secret: {}", hex::encode(shared_secret));
+
+        let mut f1_es = SimpleHmac::<Sha3_256>::new_from_slice(ephemeral_secret.as_ref())
+            .expect("Keying server f1_es hmac should never fail");
+
+        // derive the mark from the Ephemeral Secret
+        let client_mark = {
+            f1_es.reset();
+            f1_es.update(&client_ek_obfs);
+            f1_es.update(&client_ct_obfs);
+            f1_es.update(CLIENT_MARK_ARG);
+            f1_es.finalize_reset().into_bytes()
+        };
+
+        trace!(
+            "{} mark?:{}",
+            materials.session_id,
+            hex::encode(client_mark)
+        );
+
+        let min_position = K::CT_SIZE + K::EK_SIZE + MIN_PAD_LENGTH;
+
+        // find mark + mac position
+        let pos = match find_mac_mark::<D>(client_mark, buf, min_position, MAX_PACKET_LENGTH, true)
+        {
+            Some(p) => p,
+            None => {
+                trace!("{} didn't find mark", materials.session_id);
+                if buf.len() > MAX_PACKET_LENGTH {
+                    Err(RelayHandshakeError::BadClientHandshake)?
+                }
+                Err(RelayHandshakeError::EAgain)?
+            }
+        };
+
+        // validate he MAC
+        let mut mac_found = false;
+        let mut epoch_hour = String::new();
+        for offset in [0_i64, -1, 1] {
+            // Allow the epoch to be off by up to one hour in either direction
+            trace!("server trying offset: {offset}");
+            let eh = format!("{}", offset + get_epoch_hour() as i64);
+
+            // compute the expected MAC (if the epoch hour is within the valid range)
+            f1_es.reset();
+            f1_es.update(&buf[..pos + D::MARK_SIZE]);
+            f1_es.update(eh.as_bytes());
+            f1_es.update(CLIENT_MAC_ARG);
+            let mac_calculated = &f1_es.finalize_reset().into_bytes()[..D::MAC_SIZE];
+
+            // check received mac
+            let mac_received = &buf[pos + D::MARK_SIZE..pos + D::MARK_SIZE + D::MAC_SIZE];
+            trace!(
+                "server {}-{}",
+                hex::encode(mac_calculated),
+                hex::encode(mac_received)
+            );
+
+            // // make sure that the clients mac matches and that both x25519 keys contributed (i.e. neither was 0)
+            // let mut okay = computed_mac.ct_eq(&msg_mac)
+            //     & ct::bool_to_choice(xy.was_contributory())
+            //     & ct::bool_to_choice(xb.was_contributory());
+
+            if mac_calculated.ct_eq(mac_received).into() {
+                trace!("correct mac");
+                // Ensure that this handshake has not been seen previously.
+                if self
+                    .server
+                    .replay_filter
+                    .test_and_set(Instant::now(), mac_received)
+                {
+                    // The client either happened to generate exactly the same
+                    // session key and padding, or someone is replaying a previous
+                    // handshake.  In either case, fuck them.
+                    Err(RelayHandshakeError::ReplayedHandshake)?
+                }
+
+                epoch_hour = eh;
+                mac_found = true;
+
+                // We break here, but if this creates some kind of timing channel
+                // (not sure exactly what that would be) we could reduce timing variance by
+                // just evaluating all three MACs. Probably not necessary
+                break;
+            }
+        }
+
+        if !mac_found {
+            // This could be a [`RelayHandshakeError::TagMismatch`] :shrug:
+            trace!("Matching MAC not found");
+            Err(RelayHandshakeError::BadClientHandshake)?
+        }
+
+        // client should never send any appended padding at the end.
+        if buf.len() != pos + D::MARK_SIZE + D::MAC_SIZE {
+            trace!("client sent extra data");
+            Err(RelayHandshakeError::BadClientHandshake)?
+        }
+
+        let client_ephemeral_ek = EphemeralPub::<K>::try_from_bytes(client_ek_obfs)
+            .map_err(|_| RelayHandshakeError::FailedParse)?;
+        Ok(ClientHandshakeMessage::<K, ClientStateIncoming<D>>::new(
+            client_ephemeral_ek,
+            ClientStateIncoming::new(ephemeral_secret),
+            Some(epoch_hour),
+        ))
+
+        // Is it important that the context for the auth HMAC uses the non obfuscated encoding of the
+        // ciphertext sent by the client (ciphertext created using the server's identity encapsulation
+        // key) as opposed to the obfuscated encoding?
+        //
+        // No this should not impact things.
+
+        // -----------------------------------[NTor V3]-------------------------------
+        // // TODO: Maybe use the Reader / Ntor interface, it is nice and clean.
+        // // Decode the message.
+
+        // let mut r = Reader::from_slice(message);
+        // let id: Ed25519Identity = r.extract()?;
+        // let requested_pk: IdentityPublicKey<K> = r.extract()?;
+        // let client_pk: SessionPublicKey = r.extract()?;
+        // let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
+        //     r.take(msg_len)?
+        // } else {
+        //     let deficit = (MAC_LEN - r.remaining())
+        //         .try_into()
+        //         .expect("miscalculated!");
+        //     return Err(Error::incomplete_error(deficit).into());
+        // };
+
+        // let msg_mac: MessageMac = r.extract()?;
+        // r.should_be_exhausted()?;
+
+        // // See if we recognize the provided (id,requested_pk) pair.
+        // let keypair = match keys.matches(id, requested_pk.pk).into() {
+        //     Some(k) => keys,
+        //     None => return Err(RelayHandshakeError::MissingKey),
+        // };
+    }
 }

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -29,11 +29,8 @@ pub(crate) struct HandshakeMaterials {
     pub(crate) len_seed: [u8; SEED_LENGTH],
 }
 
-impl<'a> HandshakeMaterials {
-    pub fn new<'b>(session_id: String, len_seed: [u8; SEED_LENGTH]) -> Self
-    where
-        'b: 'a,
-    {
+impl HandshakeMaterials {
+    pub fn new(session_id: String, len_seed: [u8; SEED_LENGTH]) -> Self {
         HandshakeMaterials {
             session_id,
             len_seed,

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -31,7 +31,7 @@ pub(crate) struct HandshakeMaterials {
 
 impl<'a> HandshakeMaterials {
     pub fn get_hmac<'b>(&self, identity_keys: &'b IdentitySecretKey) -> Hmac<Sha256> {
-        let mut key = identity_keys.pk.pk.as_bytes().to_vec();
+        let mut key = identity_keys.pk.ek.as_bytes().to_vec();
         key.append(&mut identity_keys.pk.id.as_bytes().to_vec());
         Hmac::<Sha256>::new_from_slice(&key[..]).unwrap()
     }
@@ -96,8 +96,8 @@ pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply>(
     keys: &IdentitySecretKey,
     verification: &[u8],
 ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    let secret_key_y = SessionSecretKey::random_from_rng(rng);
-    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &secret_key_y, message, keys, verification)
+    let (dk_session, _ek_session) = xwing::generate_key_pair(rng);
+    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &dk_session, message, keys, verification)
 }
 
 /// As `server_handshake_ntor_v3`, but take a secret key instead of an RNG.

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -109,117 +109,119 @@ pub(crate) fn server_handshake_ntor_v3_no_keygen<R: CryptoRng + RngCore, REPLY: 
     keys: &IdentitySecretKey,
     verification: &[u8],
 ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
-    // Decode the message.
-    let mut r = Reader::from_slice(message);
-    let id: Ed25519Identity = r.extract()?;
-    let requested_pk: IdentityPublicKey = r.extract()?;
-    let client_pk: SessionPublicKey = r.extract()?;
-    let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
-        r.take(msg_len)?
-    } else {
-        let deficit = (MAC_LEN - r.remaining())
-            .try_into()
-            .expect("miscalculated!");
-        return Err(Error::incomplete_error(deficit).into());
-    };
+    todo!("server handshake");
 
-    let msg_mac: MessageMac = r.extract()?;
-    r.should_be_exhausted()?;
+    // // Decode the message.
+    // let mut r = Reader::from_slice(message);
+    // let id: Ed25519Identity = r.extract()?;
+    // let requested_pk: IdentityPublicKey = r.extract()?;
+    // let client_pk: SessionPublicKey = r.extract()?;
+    // let client_msg = if let Some(msg_len) = r.remaining().checked_sub(MAC_LEN) {
+    //     r.take(msg_len)?
+    // } else {
+    //     let deficit = (MAC_LEN - r.remaining())
+    //         .try_into()
+    //         .expect("miscalculated!");
+    //     return Err(Error::incomplete_error(deficit).into());
+    // };
 
-    // See if we recognize the provided (id,requested_pk) pair.
-    let keypair = match keys.matches(id, requested_pk.pk).into() {
-        Some(k) => keys,
-        None => return Err(RelayHandshakeError::MissingKey),
-    };
+    // let msg_mac: MessageMac = r.extract()?;
+    // r.should_be_exhausted()?;
 
-    let xb = keypair
-        .hpke(rng, &client_pk)
-        .map_err(|e| Error::Crypto(e.into()))?;
-    let (enc_key, mut mac) = kdf_msgkdf(&xb, &keypair.pk, &client_pk, verification)
-        .map_err(into_internal!("Can't apply ntor3 kdf."))?;
-    // Verify the message we received.
-    let computed_mac: DigestVal = {
-        mac.write(client_msg)
-            .map_err(into_internal!("Can't compute MAC input."))?;
-        mac.take().finalize().into()
-    };
-    let y_pk = SessionPublicKey::from(secret_key_y);
-    let xy = secret_key_y.hpke(rng, &client_pk)?;
+    // // See if we recognize the provided (id,requested_pk) pair.
+    // let keypair = match keys.matches(id, requested_pk.pk).into() {
+    //     Some(k) => keys,
+    //     None => return Err(RelayHandshakeError::MissingKey),
+    // };
 
-    let mut okay = computed_mac.ct_eq(&msg_mac)
-        & ct::bool_to_choice(xy.was_contributory())
-        & ct::bool_to_choice(xb.was_contributory());
+    // let xb = keypair
+    //     .hpke(rng, &client_pk)
+    //     .map_err(|e| Error::Crypto(e.into()))?;
+    // let (enc_key, mut mac) = kdf_msgkdf(&xb, &keypair.pk, &client_pk, verification)
+    //     .map_err(into_internal!("Can't apply ntor3 kdf."))?;
+    // // Verify the message we received.
+    // let computed_mac: DigestVal = {
+    //     mac.write(client_msg)
+    //         .map_err(into_internal!("Can't compute MAC input."))?;
+    //     mac.take().finalize().into()
+    // };
+    // let y_pk = SessionPublicKey::from(secret_key_y);
+    // let xy = secret_key_y.hpke(rng, &client_pk)?;
 
-    let plaintext_msg = decrypt(&enc_key, client_msg);
+    // let mut okay = computed_mac.ct_eq(&msg_mac)
+    //     & ct::bool_to_choice(xy.was_contributory())
+    //     & ct::bool_to_choice(xb.was_contributory());
 
-    // Handle the message and decide how to reply.
-    let reply = reply_fn.reply(&plaintext_msg);
+    // let plaintext_msg = decrypt(&enc_key, client_msg);
 
-    // It's not exactly constant time to use is_some() and
-    // unwrap_or_else() here, but that should be somewhat
-    // hidden by the rest of the computation.
-    okay &= ct::bool_to_choice(reply.is_some());
-    let reply = reply.unwrap_or_default();
+    // // Handle the message and decide how to reply.
+    // let reply = reply_fn.reply(&plaintext_msg);
 
-    // If we reach this point, we are actually replying, or pretending
-    // that we're going to reply.
+    // // It's not exactly constant time to use is_some() and
+    // // unwrap_or_else() here, but that should be somewhat
+    // // hidden by the rest of the computation.
+    // okay &= ct::bool_to_choice(reply.is_some());
+    // let reply = reply.unwrap_or_default();
 
-    let secret_input = {
-        let mut si = SecretBuf::new();
-        si.write(&xy.as_bytes())
-            .and_then(|_| si.write(&xb.as_bytes()))
-            .and_then(|_| si.write(&keypair.pk.id))
-            .and_then(|_| si.write(&keypair.pk.pk.as_bytes()))
-            .and_then(|_| si.write(&client_pk.as_bytes()))
-            .and_then(|_| si.write(&y_pk.as_bytes()))
-            .and_then(|_| si.write(PROTOID))
-            .and_then(|_| si.write(&Encap(verification)))
-            .map_err(into_internal!("can't derive ntor3 secret_input"))?;
-        si
-    };
-    let ntor_key_seed = h_key_seed(&secret_input);
-    let verify = h_verify(&secret_input);
+    // // If we reach this point, we are actually replying, or pretending
+    // // that we're going to reply.
 
-    let (enc_key, keystream) = {
-        let mut xof = DigestWriter(Shake256::default());
-        xof.write(&T_FINAL)
-            .and_then(|_| xof.write(&ntor_key_seed))
-            .map_err(into_internal!("can't generate ntor3 xof."))?;
-        let mut r = xof.take().finalize_xof();
-        let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
-        r.read(&mut enc_key[..]);
-        (enc_key, r)
-    };
-    let encrypted_reply = encrypt(&enc_key, &reply);
-    let auth: DigestVal = {
-        let mut auth = DigestWriter(Sha3_256::default());
-        auth.write(&T_AUTH)
-            .and_then(|_| auth.write(&verify))
-            .and_then(|_| auth.write(&keypair.pk.id))
-            .and_then(|_| auth.write(&keypair.pk.pk.as_bytes()))
-            .and_then(|_| auth.write(&y_pk.as_bytes()))
-            .and_then(|_| auth.write(&client_pk.as_bytes()))
-            .and_then(|_| auth.write(&msg_mac))
-            .and_then(|_| auth.write(&Encap(&encrypted_reply)))
-            .and_then(|_| auth.write(PROTOID))
-            .and_then(|_| auth.write(&b"Server"[..]))
-            .map_err(into_internal!("can't derive ntor3 authentication"))?;
-        auth.take().finalize().into()
-    };
+    // let secret_input = {
+    //     let mut si = SecretBuf::new();
+    //     si.write(&xy.as_bytes())
+    //         .and_then(|_| si.write(&xb.as_bytes()))
+    //         .and_then(|_| si.write(&keypair.pk.id))
+    //         .and_then(|_| si.write(&keypair.pk.pk.as_bytes()))
+    //         .and_then(|_| si.write(&client_pk.as_bytes()))
+    //         .and_then(|_| si.write(&y_pk.as_bytes()))
+    //         .and_then(|_| si.write(PROTOID))
+    //         .and_then(|_| si.write(&Encap(verification)))
+    //         .map_err(into_internal!("can't derive ntor3 secret_input"))?;
+    //     si
+    // };
+    // let ntor_key_seed = h_key_seed(&secret_input);
+    // let verify = h_verify(&secret_input);
 
-    let reply = {
-        let mut reply = Vec::new();
-        reply
-            .write(&y_pk.as_bytes())
-            .and_then(|_| reply.write(&auth))
-            .and_then(|_| reply.write(&encrypted_reply))
-            .map_err(into_internal!("can't encode ntor3 reply."))?;
-        reply
-    };
+    // let (enc_key, keystream) = {
+    //     let mut xof = DigestWriter(Shake256::default());
+    //     xof.write(&T_FINAL)
+    //         .and_then(|_| xof.write(&ntor_key_seed))
+    //         .map_err(into_internal!("can't generate ntor3 xof."))?;
+    //     let mut r = xof.take().finalize_xof();
+    //     let mut enc_key = Zeroizing::new([0_u8; ENC_KEY_LEN]);
+    //     r.read(&mut enc_key[..]);
+    //     (enc_key, r)
+    // };
+    // let encrypted_reply = encrypt(&enc_key, &reply);
+    // let auth: DigestVal = {
+    //     let mut auth = DigestWriter(Sha3_256::default());
+    //     auth.write(&T_AUTH)
+    //         .and_then(|_| auth.write(&verify))
+    //         .and_then(|_| auth.write(&keypair.pk.id))
+    //         .and_then(|_| auth.write(&keypair.pk.pk.as_bytes()))
+    //         .and_then(|_| auth.write(&y_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&client_pk.as_bytes()))
+    //         .and_then(|_| auth.write(&msg_mac))
+    //         .and_then(|_| auth.write(&Encap(&encrypted_reply)))
+    //         .and_then(|_| auth.write(PROTOID))
+    //         .and_then(|_| auth.write(&b"Server"[..]))
+    //         .map_err(into_internal!("can't derive ntor3 authentication"))?;
+    //     auth.take().finalize().into()
+    // };
 
-    if okay.into() {
-        Ok((reply, NtorV3XofReader::new(keystream)))
-    } else {
-        Err(RelayHandshakeError::BadClientHandshake)
-    }
+    // let reply = {
+    //     let mut reply = Vec::new();
+    //     reply
+    //         .write(&y_pk.as_bytes())
+    //         .and_then(|_| reply.write(&auth))
+    //         .and_then(|_| reply.write(&encrypted_reply))
+    //         .map_err(into_internal!("can't encode ntor3 reply."))?;
+    //     reply
+    // };
+
+    // if okay.into() {
+    //     Ok((reply, NtorV3XofReader::new(keystream)))
+    // } else {
+    //     Err(RelayHandshakeError::BadClientHandshake)
+    // }
 }

--- a/crates/o5/src/handshake/server.rs
+++ b/crates/o5/src/handshake/server.rs
@@ -83,7 +83,7 @@ impl ServerHandshake for Server {
 ///
 /// On success, return the server handshake message to send, and an XofReader
 /// to use in generating circuit keys.
-pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply, K:OKemCore>(
+pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply, K: OKemCore>(
     rng: &mut R,
     reply_fn: &mut REPLY,
     message: &[u8],
@@ -91,11 +91,16 @@ pub(crate) fn server_handshake_ntor_v3<R: CryptoRng + RngCore, REPLY: MsgReply, 
     verification: &[u8],
 ) -> RelayHandshakeResult<(Vec<u8>, NtorV3XofReader)> {
     let (dk_session, _ek_session) = K::generate(rng);
-    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &dk_session, message, keys, verification)
+    let ephemeral_dk = EphemeralKey::new(dk_session);
+    server_handshake_ntor_v3_no_keygen(rng, reply_fn, &ephemeral_dk, message, keys, verification)
 }
 
 /// As `server_handshake_ntor_v3`, but take a secret key instead of an RNG.
-pub(crate) fn server_handshake_ntor_v3_no_keygen<R: CryptoRng + RngCore, REPLY: MsgReply, K:OKemCore>(
+pub(crate) fn server_handshake_ntor_v3_no_keygen<
+    R: CryptoRng + RngCore,
+    REPLY: MsgReply,
+    K: OKemCore,
+>(
     rng: &mut R,
     reply_fn: &mut REPLY,
     secret_key_y: &EphemeralKey<K>,

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -2,17 +2,24 @@
 // #![warn(missing_docs)]
 #![allow(unused)]
 
+use digest::FixedOutputReset;
+
 pub mod client;
 pub mod common;
+pub mod extensions;
 pub mod framing;
 pub mod proto;
 pub mod server;
 pub use client::{Client, ClientBuilder};
 pub use server::{Server, ServerBuilder};
 
+
+#[rustfmt::skip]
 pub(crate) mod constants;
 pub(crate) mod handshake;
 pub(crate) mod sessions;
+pub(crate) mod traits;
+pub use traits::Digest;
 
 #[cfg(test)]
 mod testing;
@@ -23,7 +30,14 @@ pub use pt::{Transport, O5PT};
 mod error;
 pub use error::{Error, Result};
 
-pub const TRANSPORT_NAME: &str = "o5";
+macro_rules! transport_name {
+    () => {
+        "o5"
+    };
+}
+pub(crate) use transport_name;
+
+pub const TRANSPORT_NAME: &str = transport_name!();
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,4 +1,6 @@
 #![doc = include_str!("../README.md")]
+
+// #![warn(missing_docs)]
 #![allow(unused)]
 
 pub mod client;

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-
 // #![warn(missing_docs)]
 #![allow(unused)]
 

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -28,7 +28,7 @@ pub const TRANSPORT_NAME: &str = "o5";
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, test))]
 pub mod dev {
     /// Pre-generated / shared key for use while running in debug mode.
     pub const DEV_PRIV_KEY: &[u8; 32] = b"0123456789abcdeffedcba9876543210";

--- a/crates/o5/src/lib.rs
+++ b/crates/o5/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(unused)]
 
 pub mod client;
 pub mod common;

--- a/crates/o5/src/proto.rs
+++ b/crates/o5/src/proto.rs
@@ -6,12 +6,12 @@ use crate::{
     constants::*,
     framing,
     sessions::Session,
+    traits::OKemCore,
     Result,
 };
 
 use bytes::{Buf, BytesMut};
 use futures::{Sink, Stream};
-use kemeleon::OKemCore;
 use pin_project::pin_project;
 use ptrs::trace;
 use sha2::{Digest, Sha256};

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -1,7 +1,4 @@
-use crate::{
-    common::xwing, constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error,
-    TRANSPORT_NAME,
-};
+use crate::{constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error, TRANSPORT_NAME};
 use ptrs::{args::Args, FutureResult as F};
 
 use std::{
@@ -13,8 +10,8 @@ use std::{
 };
 
 use hex::FromHex;
-use ptrs::trace;
 use kemeleon::{Encode, MlKem768};
+use ptrs::trace;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -14,6 +14,7 @@ use std::{
 
 use hex::FromHex;
 use ptrs::trace;
+use kemeleon::MlKem768;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
@@ -196,11 +197,11 @@ where
     type Builder = crate::ClientBuilder;
 
     fn establish(self, input: Pin<F<InRW, InErr>>) -> Pin<F<Self::OutRW, Self::OutErr>> {
-        Box::pin(crate::Client::establish(self, input))
+        Box::pin(crate::Client::establish::<InRW, InErr, MlKem768>(self, input))
     }
 
     fn wrap(self, io: InRW) -> Pin<F<Self::OutRW, Self::OutErr>> {
-        Box::pin(crate::Client::wrap(self, io))
+        Box::pin(crate::Client::wrap::<InRW, MlKem768>(self, io))
     }
 
     fn method_name() -> String {

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -74,7 +74,7 @@ where
 
         trace!(
             "node_pubkey: {}, node_id: {}",
-            hex::encode(self.identity_keys.pk.pk.as_bytes()),
+            hex::encode(self.identity_keys.pk.ek.as_bytes()),
             hex::encode(self.identity_keys.pk.id.as_bytes()),
         );
         Ok(self)

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -57,7 +57,7 @@ where
     type Error = Error;
     type Transport = Transport<T>;
 
-    fn build(&self) -> Self::ServerPT {
+    fn build(self) -> Self::ServerPT {
         crate::ServerBuilder::build(self)
     }
 
@@ -223,6 +223,10 @@ where
 
     fn method_name() -> String {
         TRANSPORT_NAME.into()
+    }
+
+    fn get_client_params(&self) -> String {
+        self.client_params().as_opts()
     }
 }
 

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -197,11 +197,11 @@ where
     type Builder = crate::ClientBuilder;
 
     fn establish(self, input: Pin<F<InRW, InErr>>) -> Pin<F<Self::OutRW, Self::OutErr>> {
-        Box::pin(crate::Client::establish::<InRW, InErr, MlKem768>(self, input))
+        Box::pin(Self::establish::<InRW, InErr>(self, input))
     }
 
     fn wrap(self, io: InRW) -> Pin<F<Self::OutRW, Self::OutErr>> {
-        Box::pin(crate::Client::wrap::<InRW, MlKem768>(self, io))
+        Box::pin(Self::wrap::<InRW>(self, io))
     }
 
     fn method_name() -> String {
@@ -219,7 +219,7 @@ where
 
     /// Use something that can be accessed reference (Arc, Rc, etc.)
     fn reveal(self, io: InRW) -> Pin<F<Self::OutRW, Self::OutErr>> {
-        Box::pin(crate::Server::wrap(self, io))
+        Box::pin(Self::wrap(self, io))
     }
 
     fn method_name() -> String {

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -1,10 +1,14 @@
-use crate::{constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error, TRANSPORT_NAME};
+use crate::{
+    common::xwing, constants::*, handshake::IdentityPublicKey, proto::O5Stream, Error,
+    TRANSPORT_NAME,
+};
 use ptrs::{args::Args, FutureResult as F};
 
 use std::{
     marker::PhantomData,
     net::{SocketAddrV4, SocketAddrV6},
     pin::Pin,
+    str::FromStr,
     time::Duration,
 };
 
@@ -148,13 +152,8 @@ where
             }
         };
 
-        self.with_node_pubkey(server_materials.pk.to_bytes())
-            .with_node_id(server_materials.id.into());
-        trace!(
-            "node_pubkey: {}, node_id: {}",
-            hex::encode(self.station_pubkey),
-            hex::encode(self.station_id),
-        );
+        self.with_node(server_materials);
+        trace!("node details: {:?}", &self.node_details,);
 
         Ok(self)
     }

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -189,7 +189,7 @@ where
     InRW: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
     InErr: std::error::Error + Send + Sync + 'static,
 {
-    type OutRW = O5Stream<InRW>;
+    type OutRW = O5Stream<InRW, MlKem768>;
     type OutErr = Error;
     type Builder = crate::ClientBuilder;
 
@@ -210,7 +210,7 @@ impl<InRW> ptrs::ServerTransport<InRW> for crate::Server
 where
     InRW: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
 {
-    type OutRW = O5Stream<InRW>;
+    type OutRW = O5Stream<InRW, MlKem768>;
     type OutErr = Error;
     type Builder = crate::ServerBuilder<InRW>;
 

--- a/crates/o5/src/pt.rs
+++ b/crates/o5/src/pt.rs
@@ -14,7 +14,7 @@ use std::{
 
 use hex::FromHex;
 use ptrs::trace;
-use kemeleon::MlKem768;
+use kemeleon::{Encode, MlKem768};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,

--- a/crates/o5/src/server.rs
+++ b/crates/o5/src/server.rs
@@ -285,10 +285,7 @@ impl Server {
 
     pub fn client_params(&self) -> ClientBuilder {
         ClientBuilder {
-            // these unwraps should be safe as we are sure of the size of the source
-            station_pubkey: self.identity_keys.pk.pk.as_bytes().try_into().unwrap(),
-            station_id: self.identity_keys.pk.id.as_bytes().try_into().unwrap(),
-
+            node_details: self.identity_keys.pk.clone(),
             statefile_path: None,
             handshake_timeout: MaybeTimeout::Default_,
         }

--- a/crates/o5/src/server.rs
+++ b/crates/o5/src/server.rs
@@ -25,6 +25,7 @@ use std::{
 use bytes::{Buf, BufMut, Bytes};
 use hex::FromHex;
 use hmac::{Hmac, Mac};
+use kemeleon::MlKem768;
 use ptrs::{debug, info};
 use rand::prelude::*;
 use subtle::ConstantTimeEq;
@@ -258,7 +259,7 @@ impl Server {
         Self::new_from_key(identity_keys)
     }
 
-    pub async fn wrap<T>(self, stream: T) -> Result<O5Stream<T>>
+    pub async fn wrap<T>(self, stream: T) -> Result<O5Stream<T, MlKem768>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {

--- a/crates/o5/src/server.rs
+++ b/crates/o5/src/server.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     constants::*,
     framing::{FrameError, Marshall, O5Codec, TryParse, KEY_LENGTH},
-    handshake::{IdentityPub, IdentityKey},
+    handshake::{IdentityKey, IdentityPub},
     proto::{MaybeTimeout, O5Stream},
     sessions::Session,
     Error, Result,

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -2,9 +2,8 @@
 //!
 /// Session state management as a way to organize session establishment and
 /// steady state transfer.
-use crate::common::drbg;
+use crate::{common::drbg, traits::OKemCore, Digest};
 
-use kemeleon::{MlKem768, OKemCore};
 use tor_bytes::Readable;
 
 mod client;

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -1,9 +1,10 @@
-//! obfs4 session details and construction
+//! obfs5 session details and construction
 //!
 /// Session state management as a way to organize session establishment and
 /// steady state transfer.
 use crate::common::{drbg, xwing};
 
+use kemeleon::OKemCore;
 use tor_bytes::Readable;
 
 mod client;
@@ -11,18 +12,6 @@ pub(crate) use client::{new_client_session, ClientSession};
 
 mod server;
 pub(crate) use server::ServerSession;
-
-/// Ephermeral single use session secret key type
-pub type SessionSecretKey = xwing::DecapsulationKey;
-
-/// Public key type associated with SessionSecretKey.
-pub type SessionPublicKey = xwing::EncapsulationKey;
-
-impl Readable for SessionPublicKey {
-    fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {
-        todo!("SessionPublicKey Reader needs implemented");
-    }
-}
 
 /// Initial state for a Session, created with any params.
 pub(crate) struct Initialized;

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -2,7 +2,7 @@
 //!
 /// Session state management as a way to organize session establishment and
 /// steady state transfer.
-use crate::common::{drbg, mlkem1024_x25519};
+use crate::common::{drbg, xwing};
 
 use tor_bytes::Readable;
 
@@ -13,18 +13,16 @@ mod server;
 pub(crate) use server::ServerSession;
 
 /// Ephermeral single use session secret key type
-pub type SessionSecretKey = mlkem1024_x25519::StaticSecret;
+pub type SessionSecretKey = xwing::StaticSecret;
 
 /// Public key type associated with SessionSecretKey.
-pub type SessionPublicKey = mlkem1024_x25519::PublicKey;
-
+pub type SessionPublicKey = xwing::PublicKey;
 
 impl Readable for SessionPublicKey {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {
         todo!("SessionPublicKey Reader needs implemented");
     }
 }
-
 
 /// Initial state for a Session, created with any params.
 pub(crate) struct Initialized;

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -13,10 +13,10 @@ mod server;
 pub(crate) use server::ServerSession;
 
 /// Ephermeral single use session secret key type
-pub type SessionSecretKey = xwing::StaticSecret;
+pub type SessionSecretKey = xwing::DecapsulationKey;
 
 /// Public key type associated with SessionSecretKey.
-pub type SessionPublicKey = xwing::PublicKey;
+pub type SessionPublicKey = xwing::EncapsulationKey;
 
 impl Readable for SessionPublicKey {
     fn take_from(_b: &mut tor_bytes::Reader<'_>) -> tor_bytes::Result<Self> {

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -2,7 +2,7 @@
 //!
 /// Session state management as a way to organize session establishment and
 /// steady state transfer.
-use crate::common::{drbg, xwing};
+use crate::common::drbg;
 
 use kemeleon::OKemCore;
 use tor_bytes::Readable;

--- a/crates/o5/src/sessions.rs
+++ b/crates/o5/src/sessions.rs
@@ -4,7 +4,7 @@
 /// steady state transfer.
 use crate::common::drbg;
 
-use kemeleon::OKemCore;
+use kemeleon::{MlKem768, OKemCore};
 use tor_bytes::Readable;
 
 mod client;
@@ -22,12 +22,12 @@ pub(crate) struct Established;
 /// The session broke due to something like a timeout, reset, lost connection, etc.
 trait Fault {}
 
-pub enum Session {
-    Client(ClientSession<Established>),
+pub enum Session<K: OKemCore> {
+    Client(ClientSession<Established, K>),
     Server(ServerSession<Established>),
 }
 
-impl Session {
+impl<K: OKemCore> Session<K> {
     #[allow(unused)]
     pub fn id(&self) -> String {
         match self {

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -14,13 +14,17 @@ use crate::{
     },
     proto::{O5Stream, ObfuscatedStream},
     sessions::{Established, Fault, Initialized, Session},
-    Error, Result,
+    traits::OKemCore,
+    Digest, Error, Result,
 };
 
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use std::{
+    io::{Error as IoError, ErrorKind as IoErrorKind},
+    marker::PhantomData,
+};
 
 use bytes::{BufMut, BytesMut};
-use kemeleon::{Encode, OKemCore};
+use kemeleon::Encode;
 use ptrs::{debug, info};
 use rand_core::RngCore;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -140,13 +144,14 @@ impl<K: OKemCore> ClientSession<Initialized, K> {
     /// - response fails server auth check
     ///
     /// TODO: make sure failure modes are understood (FIN/RST w/ and w/out buffered data, etc.)
-    pub async fn handshake<T>(
+    pub async fn handshake<T, D>(
         self,
         mut stream: T,
         deadline: Option<Instant>,
     ) -> Result<O5Stream<T, K>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
+        D: Digest,
     {
         // set up for handshake
         let mut session = self.transition(ClientHandshaking {});
@@ -155,7 +160,7 @@ impl<K: OKemCore> ClientSession<Initialized, K> {
 
         // default deadline
         let d_def = Instant::now() + CLIENT_HANDSHAKE_TIMEOUT;
-        let handshake_fut = Self::complete_handshake::<T>(stream, materials, deadline);
+        let handshake_fut = Self::complete_handshake::<T, D>(stream, materials, deadline);
         let (mut hs_complete, mut stream) =
             match tokio::time::timeout_at(deadline.unwrap_or(d_def), handshake_fut).await {
                 Ok(result) => match result {
@@ -208,7 +213,7 @@ impl<K: OKemCore> ClientSession<Initialized, K> {
         Ok(O5Stream::from_o4(o4))
     }
 
-    async fn complete_handshake<T>(
+    async fn complete_handshake<T, D>(
         mut stream: T,
         materials: CHSMaterials<K>,
         deadline: Option<Instant>,
@@ -218,9 +223,11 @@ impl<K: OKemCore> ClientSession<Initialized, K> {
     )>
     where
         T: AsyncRead + AsyncWrite + Unpin,
+        D: Digest,
     {
         // let session_id = materials.session_id;
-        let (mut state, chs_message) = NtorV3Client::<K>::client1(materials)?;
+        let mut chs_message = BytesMut::new();
+        let mut state = NtorV3Client::<K, D>::client1(materials, &mut chs_message)?;
         // let mut file = tokio::fs::File::create("message.hex").await?;
         // file.write_all(&chs_message).await?;
         stream.write_all(&chs_message).await?;
@@ -231,7 +238,7 @@ impl<K: OKemCore> ClientSession<Initialized, K> {
             chs_message.len()
         );
 
-        let mut buf = [0u8; MAX_HANDSHAKE_LENGTH];
+        let mut buf = [0u8; MAX_PACKET_LENGTH];
         loop {
             let n = stream.read(&mut buf).await?;
             if n == 0 {

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -138,7 +138,11 @@ impl ClientSession<Initialized> {
     /// - response fails server auth check
     ///
     /// TODO: make sure failure modes are understood (FIN/RST w/ and w/out buffered data, etc.)
-    pub async fn handshake<T, K>(self, mut stream: T, deadline: Option<Instant>) -> Result<O5Stream<T>>
+    pub async fn handshake<T, K>(
+        self,
+        mut stream: T,
+        deadline: Option<Instant>,
+    ) -> Result<O5Stream<T>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
         K: OKemCore,

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -275,7 +275,7 @@ impl<S: ClientSessionState> std::fmt::Debug for ClientSession<S> {
             f,
             "[ id:{}, ident_pk:{}, epoch_hr:{} ]",
             hex::encode(self.node_pubkey.id.as_bytes()),
-            hex::encode(self.node_pubkey.pk.as_bytes()),
+            hex::encode(self.node_pubkey.ek.as_bytes()),
             self.epoch_hour,
         )
     }

--- a/crates/o5/src/sessions/client.rs
+++ b/crates/o5/src/sessions/client.rs
@@ -1,11 +1,17 @@
 use crate::{
     common::{
         discard, drbg,
-        ntor_arti::{ClientHandshake, RelayHandshakeError, SessionID, SessionIdentifier},
+        ntor_arti::{
+            ClientHandshake, ClientHandshakeComplete, RelayHandshakeError, SessionID,
+            SessionIdentifier,
+        },
     },
     constants::*,
     framing,
-    handshake::{CHSMaterials, IdentityPublicKey, NtorV3Client, NtorV3KeyGen},
+    handshake::{
+        CHSMaterials, ClientHsComplete, IdentityPublicKey, NtorV3Client, NtorV3KeyGen,
+        NtorV3KeyGenerator,
+    },
     proto::{O5Stream, ObfuscatedStream},
     sessions::{Established, Fault, Initialized, Session},
     Error, Result,
@@ -13,7 +19,7 @@ use crate::{
 
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use ptrs::{debug, info};
 use rand_core::RngCore;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -142,8 +148,9 @@ impl ClientSession<Initialized> {
 
         // default deadline
         let d_def = Instant::now() + CLIENT_HANDSHAKE_TIMEOUT;
-        let handshake_fut = Self::complete_handshake(&mut stream, materials, deadline);
-        let (mut remainder, mut keygen) =
+        let handshake_fut =
+            Self::complete_handshake::<T, ClientHsComplete>(stream, materials, deadline);
+        let (mut hs_complete, mut stream) =
             match tokio::time::timeout_at(deadline.unwrap_or(d_def), handshake_fut).await {
                 Ok(result) => match result {
                     Ok(handshake) => handshake,
@@ -166,10 +173,16 @@ impl ClientSession<Initialized> {
             };
 
         // post-handshake state updates
+        let mut keygen: NtorV3KeyGenerator = hs_complete.keygen();
         session.set_session_id(keygen.session_id());
-        let mut codec: framing::O5Codec = keygen.into();
+        let mut codec = framing::O5Codec::from(keygen);
 
-        let res = codec.decode(&mut remainder);
+        // // TODO: handle server response extensions here
+        // for ext in hs_complete.extensions() {
+        //      // do something
+        // }
+
+        let res = codec.decode(&mut hs_complete.remainder());
         if let Ok(Some(framing::Messages::PrngSeed(seed))) = res {
             // try to parse the remainder of the server hello packet as a
             // PrngSeed since it should be there.
@@ -189,23 +202,26 @@ impl ClientSession<Initialized> {
         Ok(O5Stream::from_o4(o4))
     }
 
-    async fn complete_handshake<T>(
+    async fn complete_handshake<T, O>(
         mut stream: T,
         materials: CHSMaterials,
         deadline: Option<Instant>,
-    ) -> Result<(BytesMut, impl NtorV3KeyGen<ID = SessionID>)>
+    ) -> Result<(
+        impl ClientHandshakeComplete<Remainder = BytesMut, KeyGen = NtorV3KeyGenerator>,
+        T,
+    )>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {
         // let session_id = materials.session_id;
-        let (state, chs_message) = NtorV3Client::client1(materials)?;
+        let (mut state, chs_message) = NtorV3Client::client1(materials)?;
         // let mut file = tokio::fs::File::create("message.hex").await?;
         // file.write_all(&chs_message).await?;
         stream.write_all(&chs_message).await?;
 
         debug!(
             "{} handshake sent {}B, waiting for sever response",
-            materials.session_id,
+            state.materials.session_id,
             chs_message.len()
         );
 
@@ -220,18 +236,18 @@ impl ClientSession<Initialized> {
             }
             debug!(
                 "{} read {n}/{}B of server handshake",
-                materials.session_id,
+                state.materials.session_id,
                 buf.len()
             );
 
-            match NtorV3Client::client2(state, &buf[..n]) {
-                Ok(r) => return Ok(r),
+            match NtorV3Client::client2(&mut state, &buf[..n]) {
+                Ok(r) => return Ok((r, stream)),
                 Err(Error::HandshakeErr(RelayHandshakeError::EAgain)) => continue,
                 Err(e) => {
                     // if a deadline was set and has not passed already, discard
                     // from the stream until the deadline, then close.
                     if deadline.is_some_and(|d| d > Instant::now()) {
-                        debug!("{} discarding due to: {e}", materials.session_id);
+                        debug!("{} discarding due to: {e}", state.materials.session_id);
                         discard(&mut stream, deadline.unwrap() - Instant::now()).await?;
                     }
                     stream.shutdown().await?;

--- a/crates/o5/src/sessions/server.rs
+++ b/crates/o5/src/sessions/server.rs
@@ -2,21 +2,22 @@ use crate::{
     common::{
         discard, drbg,
         ntor_arti::{
-            AuxDataReply, RelayHandshakeError, ServerHandshake, SessionID, SessionIdentifier,
+            AuxDataReply, RelayHandshakeError, ServerHandshake as _, SessionID, SessionIdentifier,
         },
     },
     constants::*,
     framing,
-    handshake::{NtorV3KeyGen, SHSMaterials},
+    handshake::{NtorV3KeyGen, SHSMaterials, ServerHandshake},
     proto::{O5Stream, ObfuscatedStream},
     server::Server,
     sessions::{Established, Fault, Initialized, Session},
-    Error, Result,
+    traits::OKemCore,
+    Digest, Error, Result,
 };
 
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
-use kemeleon::MlKem768;
+use bytes::BytesMut;
 use ptrs::{debug, info, trace};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::Instant;
@@ -116,25 +117,26 @@ impl<S: ServerSessionState> ServerSession<S> {
 
 impl ServerSession<Initialized> {
     /// Attempt to complete the handshake with a new client connection.
-    pub async fn handshake<REPLY: AuxDataReply<Server>, T>(
+    pub async fn handshake<T, K, D>(
         self,
-        server: &Server,
+        server: &Server<K, D>,
         mut stream: T,
-        extensions_handler: &mut REPLY,
+        extensions_handler: &mut impl AuxDataReply<ServerHandshake<K, D>>,
         deadline: Option<Instant>,
-    ) -> Result<O5Stream<T, MlKem768>>
+    ) -> Result<O5Stream<T, K>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
+        K: OKemCore,
+        D: Digest,
     {
         // set up for handshake
         let mut session = self.transition(ServerHandshaking {});
-
         let materials = SHSMaterials::new(session.session_id(), session.len_seed.to_bytes());
+        let handshake = server.new_handshake(materials);
+        let handshake_fut = handshake.complete_handshake(&mut stream, extensions_handler, deadline);
 
         // default deadline
         let d_def = Instant::now() + SERVER_HANDSHAKE_TIMEOUT;
-        let handshake_fut =
-            server.complete_handshake(&mut stream, extensions_handler, materials, deadline);
 
         let mut keygen =
             match tokio::time::timeout_at(deadline.unwrap_or(d_def), handshake_fut).await {
@@ -172,7 +174,15 @@ impl ServerSession<Initialized> {
     }
 }
 
-impl Server {
+impl<K: OKemCore, D: Digest> Server<K, D> {
+    ///
+    pub(crate) fn new_handshake(&self, materials: SHSMaterials) -> ServerHandshake<K, D> {
+        // clones the server Arc reference
+        ServerHandshake::new(self.clone(), materials)
+    }
+}
+
+impl<K: OKemCore, D: Digest> ServerHandshake<K, D> {
     /// Complete the handshake with the client. This function assumes that the
     /// client has already sent a message and that we do not know yet if the
     /// message is valid.
@@ -180,16 +190,16 @@ impl Server {
         &self,
         mut stream: T,
         reply_fn: &mut REPLY,
-        materials: SHSMaterials,
         deadline: Option<Instant>,
     ) -> Result<impl NtorV3KeyGen<ID = SessionID>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {
-        let session_id = materials.session_id.clone();
+        let session_id = self.materials.session_id.clone();
 
         // wait for and attempt to consume the client hello message
-        let mut buf = [0_u8; MAX_HANDSHAKE_LENGTH];
+        let mut buf = [0_u8; MAX_PACKET_LENGTH];
+        //
         loop {
             let n = stream.read(&mut buf).await?;
             if n == 0 {
@@ -198,8 +208,9 @@ impl Server {
             }
             trace!("{} successful read {n}B", session_id);
 
-            match self.server(reply_fn, &materials, &buf[..n]) {
-                Ok((keygen, response)) => {
+            let mut response = BytesMut::new();
+            match self.server(reply_fn, &buf[..n], &mut response) {
+                Ok(keygen) => {
                     stream.write_all(&response).await?;
                     info!("{} handshake complete", session_id);
                     return Ok(keygen);

--- a/crates/o5/src/sessions/server.rs
+++ b/crates/o5/src/sessions/server.rs
@@ -16,6 +16,7 @@ use crate::{
 
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 
+use kemeleon::MlKem768;
 use ptrs::{debug, info, trace};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::time::Instant;
@@ -121,7 +122,7 @@ impl ServerSession<Initialized> {
         mut stream: T,
         extensions_handler: &mut REPLY,
         deadline: Option<Instant>,
-    ) -> Result<O5Stream<T>>
+    ) -> Result<O5Stream<T, MlKem768>>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {

--- a/crates/o5/src/test_utils/fake_prng.rs
+++ b/crates/o5/src/test_utils/fake_prng.rs
@@ -6,7 +6,7 @@ impl<'a> FakePRNG<'a> {
         Self { bytes }
     }
 }
-impl<'a> rand_core::RngCore for FakePRNG<'a> {
+impl rand_core::RngCore for FakePRNG<'_> {
     fn next_u32(&mut self) -> u32 {
         rand_core::impls::next_u32_via_fill(self)
     }

--- a/crates/o5/src/test_utils/mod.rs
+++ b/crates/o5/src/test_utils/mod.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 mod fake_prng;
+pub(crate) mod test_keys;
 pub mod tests;
 pub(crate) use fake_prng::*;
 

--- a/crates/o5/src/test_utils/mod.rs
+++ b/crates/o5/src/test_utils/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 #![allow(dead_code)]
 
 mod fake_prng;

--- a/crates/o5/src/test_utils/test_keys.rs
+++ b/crates/o5/src/test_utils/test_keys.rs
@@ -1,0 +1,62 @@
+//! # Keys used for testing
+//!
+//! The hex representations of X-Wing keys are rather large. This module exists to house
+//! those representations so they don't muddy up the whole crate.
+//!
+//! ## Naming Conventions:
+//!
+//! id: Node ID
+//! b: Node identity secret key
+//! B: Node identity public key
+//!
+//! x: Client session secret Key
+//! X: Client session public Key
+//!
+//! y: Server session secret Key
+//! Y: Server session public Key
+//!
+//! within the X-Wing Keys X indicates an X25519 element, and M indicates an ML-KEM element
+//!
+//! xX: client session secret key x25519 element
+//! xM: client session secret key ML-KEM element
+//!
+//!
+//! The shared secrets used in a handshake are
+//!
+//! xB: client session secret key KEM with node identity public key
+//! Xb: server identity secret key KEM with client session public key
+//!
+//! xB == Xb == xX*BX + xM*BM = XX*bX + XM*bM
+//!
+//! Xy: server session secret key KEM with client session public key
+//! xY: client session secret key KEM with server session public key
+//!
+//! xY == Xy == xX*YX + xM*YM = XX*yX + XM*yM
+
+#[allow(non_snake_case)]
+pub struct HexKeys {
+    pub id: &'static str,
+    pub b: &'static str,
+    pub x: &'static str,
+    pub y: &'static str,
+
+    pub xB: &'static str,
+    pub xY: &'static str,
+
+    // Ciphertext of x encapsulated using B encoded using Elligator2 and Kemeleon
+    pub xB_C_EK: &'static str,
+
+    // Ciphertext of y encapsulated using X encoded using elligator2 and Kemeleon.
+    pub Xy_C_EK: &'static str,
+}
+
+pub const KEYS: [HexKeys; 1] = [HexKeys {
+    id: "aaaaaaaaaaaaaaaaaaaaaaaa9fad2af287ef942632833d21f946c6260c33fae6",
+    b: "4051daa5921cfa2a1c27b08451324919538e79e788a81b38cbed097a5dff454a",
+    x: "b825a3719147bcbe5fb1d0b0fcb9c09e51948048e2e3283d2ab7b45b5ef38b49",
+    y: "4865a5b7689dafd978f529291c7171bc159be076b92186405d13220b80e2a053",
+    xB: "",
+    xY: "",
+    xB_C_EK: "",
+    Xy_C_EK: "",
+}];

--- a/crates/o5/src/testing.rs
+++ b/crates/o5/src/testing.rs
@@ -1,10 +1,14 @@
 use crate::{test_utils::init_subscriber, Result, Server};
 
+use kemeleon::MlKem768;
 use ptrs::{debug, trace};
+use sha3::Sha3_256;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use std::cmp::Ordering;
 use std::time::Duration;
+
+pub(crate) type ServerMK768 = Server<MlKem768, Sha3_256>;
 
 #[tokio::test]
 async fn public_handshake() -> Result<()> {
@@ -12,7 +16,7 @@ async fn public_handshake() -> Result<()> {
     let (mut c, mut s) = tokio::io::duplex(65_536);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -33,7 +37,7 @@ async fn public_iface() -> Result<()> {
     let (mut c, mut s) = tokio::io::duplex(65_536);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -79,7 +83,7 @@ async fn transfer_10k_x1() -> Result<()> {
     let (c, mut s) = tokio::io::duplex(1024 * 1000);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -132,7 +136,7 @@ async fn transfer_10k_x3() -> Result<()> {
     let (c, mut s) = tokio::io::duplex(1024 * 1000);
 
     let mut rng = rand::thread_rng();
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -187,7 +191,7 @@ async fn transfer_1M_1024x1024() -> Result<()> {
     let (c, mut s) = tokio::io::duplex(1024 * 1000);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -240,7 +244,7 @@ async fn transfer_512k_x1() -> Result<()> {
     let (c, mut s) = tokio::io::duplex(1024 * 512);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {
@@ -293,7 +297,7 @@ async fn transfer_2_x() -> Result<()> {
     let (c, mut s) = tokio::io::duplex(1024 * 1000);
     let mut rng = rand::thread_rng();
 
-    let o4_server = Server::new_from_random(&mut rng);
+    let o4_server = ServerMK768::new_from_random(&mut rng);
     let client_config = o4_server.client_params();
 
     tokio::spawn(async move {

--- a/crates/o5/src/traits.rs
+++ b/crates/o5/src/traits.rs
@@ -1,0 +1,62 @@
+//! Collection of Traits used by the O5 transport implementation
+
+use typenum::Unsigned;
+
+pub trait Named {
+    const NAME: &str;
+}
+
+impl Named for kemeleon::MlKem768 {
+    const NAME: &str = "ml-kem768";
+}
+
+impl Named for sha3::Sha3_256 {
+    const NAME: &str = "sha3-256";
+}
+
+pub trait Digest:
+    digest::Digest + digest::core_api::BlockSizeUser + digest::FixedOutputReset + Named + Clone
+{
+}
+
+impl<
+        D: digest::Digest + digest::core_api::BlockSizeUser + digest::FixedOutputReset + Named + Clone,
+    > Digest for D
+{
+}
+
+pub trait OKemCore: kemeleon::OKemCore + Named {}
+impl<O: kemeleon::OKemCore + Named> OKemCore for O {}
+
+pub trait DigestSizes: Digest {
+    /// Size of an authentication value in bytes
+    const AUTH_SIZE: usize;
+    /// Size of the digest used for the mark in the o5 handshake
+    const MARK_SIZE: usize;
+    /// Size of the digest used for the MAC in the o5 handshake
+    const MAC_SIZE: usize;
+}
+
+impl<D: Digest> DigestSizes for D {
+    const AUTH_SIZE: usize = <D as digest::OutputSizeUser>::OutputSize::USIZE;
+    const MARK_SIZE: usize = <D as digest::OutputSizeUser>::OutputSize::USIZE;
+    const MAC_SIZE: usize = <D as digest::OutputSizeUser>::OutputSize::USIZE;
+}
+
+pub trait FramingSizes: OKemCore {
+    const CT_SIZE: usize;
+    const EK_SIZE: usize;
+}
+
+impl<K: OKemCore> FramingSizes for K {
+    const CT_SIZE: usize =
+        <<K as kemeleon::OKemCore>::Ciphertext as kemeleon::Encode>::EncodedSize::USIZE;
+    const EK_SIZE: usize =
+        <<K as kemeleon::OKemCore>::EncapsulationKey as kemeleon::Encode>::EncodedSize::USIZE;
+}
+
+// trait HandshakeSize {
+//     /// Minimum possible sever handshake length // TODO
+//     pub const SERVER_MIN_HANDSHAKE_LENGTH: usize =
+//     REPRESENTATIVE_LENGTH + AUTHCODE_LENGTH + MARK_LENGTH + MAC_LENGTH;
+// }

--- a/crates/obfs4/Cargo.toml
+++ b/crates/obfs4/Cargo.toml
@@ -54,10 +54,10 @@ tokio-util = { version = "0.7.10", features = ["codec", "io"]}
 bytes = "1.5.0"
 
 ## ntor_arti
-tor-cell = "0.23.0"
-tor-llcrypto = "0.23.0"
-tor-error = "0.23.0"
-tor-bytes = "0.23.0"
+tor-cell = "0.24.0"
+tor-llcrypto = "0.24.0"
+tor-error = "0.24.0"
+tor-bytes = "0.24.0"
 cipher = "0.4.4"
 zeroize = "1.7.0"
 thiserror = "1.0.56"
@@ -81,7 +81,7 @@ filetime = {version="0.2.25", optional=true}
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
 hex-literal = "0.4.1"
-tor-basic-utils = "0.23.0"
+tor-basic-utils = "0.24.0"
 
 # benches
 # criterion = "0.5"

--- a/crates/obfs4/src/pt.rs
+++ b/crates/obfs4/src/pt.rs
@@ -59,7 +59,7 @@ where
     type Error = Error;
     type Transport = Transport<T>;
 
-    fn build(&self) -> Self::ServerPT {
+    fn build(self) -> Self::ServerPT {
         crate::ServerBuilder::build(self)
     }
 
@@ -245,6 +245,10 @@ where
 
     fn method_name() -> String {
         OBFS4_NAME.into()
+    }
+
+    fn get_client_params(&self) -> String {
+        self.client_params().as_opts()
     }
 }
 

--- a/crates/obfs4/src/server.rs
+++ b/crates/obfs4/src/server.rs
@@ -103,7 +103,7 @@ impl<T> ServerBuilder<T> {
         params.encode_smethod_args()
     }
 
-    pub fn build(&self) -> Server {
+    pub fn build(self) -> Server {
         Server(Arc::new(ServerInner {
             identity_keys: self.identity_keys.clone(),
             iat_mode: self.iat_mode,

--- a/crates/ptrs/src/lib.rs
+++ b/crates/ptrs/src/lib.rs
@@ -127,6 +127,13 @@ where
 
     /// Returns a string identifier for this transport
     fn method_name() -> String;
+
+    /// Returns a string or parameters that can be used by a ['ClientBuilder']
+    /// in the `options(...)` function to properly establish a connection with
+    /// this server based on the configuration of the server when this method
+    /// is called.
+    fn get_client_params(&self) -> String;
+
 }
 
 /// Server Transport builder interface
@@ -145,7 +152,7 @@ where
     ///
     /// **Errors**
     /// If a required field has not been initialized.
-    fn build(&self) -> Self::ServerPT;
+    fn build(self) -> Self::ServerPT;
 
     /// Pluggable transport attempts to parse and validate options from a string,
     /// typically using ['parse_smethod_args'].

--- a/crates/ptrs/src/lib.rs
+++ b/crates/ptrs/src/lib.rs
@@ -133,7 +133,6 @@ where
     /// this server based on the configuration of the server when this method
     /// is called.
     fn get_client_params(&self) -> String;
-
 }
 
 /// Server Transport builder interface

--- a/doc/pq-obfs-with-extra-data.md
+++ b/doc/pq-obfs-with-extra-data.md
@@ -1,0 +1,445 @@
+
+# TODO: THIS IS FOR LAYOUT AND HAS NOT BEEN UPDATED
+
+changes still to come
+
+```
+Filename: 332-ntor-v3-with-extra-data.md
+Title: Ntor protocol with extra data, version 3.
+Author: Nick Mathewson
+Created: 12 July 2021
+Status: Closed
+```
+
+# Overview
+
+The ntor handshake is our current protocol for circuit
+establishment.
+
+So far we have two variants of the ntor handshake in use: the "ntor
+v1" that we use for everyday circuit extension (see `tor-spec.txt`)
+and the "hs-ntor" that we use for v3 onion service handshake (see
+`rend-spec-v3.txt`).  This document defines a third version of ntor,
+adapting the improvements from hs-ntor for use in regular circuit
+establishment.
+
+These improvements include:
+
+ * Support for sending additional encrypted and authenticated
+   protocol-setup handshake data as part of the ntor handshake.  (The
+   information sent from the client to the relay does not receive
+   forward secrecy.)
+
+ * Support for using an external shared secret that both parties must
+   know in order to complete the handshake.  (In the HS handshake, this
+   is the subcredential.  We don't use it for circuit extension, but in
+   theory we could.)
+
+ * Providing a single specification that can, in the future, be used
+   both for circuit extension _and_ HS introduction.
+
+# The improved protocol: an abstract view
+
+Given a client "C" that wants to construct a circuit to a
+relay "S":
+
+The client knows:
+  * B: a public "onion key" for S
+  * ID: an identity for S, represented as a fixed-length
+    byte string.
+  * CM: a message that it wants to send to S as part of the
+    handshake.
+  * An optional "verification" string.
+
+The relay knows:
+  * A set of \[(b,B)...\] "onion key" keypairs.  One of them is
+    "current", the others are outdated, but still valid.
+  * ID: Its own identity.
+  * A function for computing a server message SM, based on a given
+    client message.
+  * An optional "verification" string. This must match the "verification"
+    string from the client.
+
+Both parties have a strong source of randomness.
+
+Given this information, the client computes a "client handshake"
+and sends it to the relay.
+
+The relay then uses its information plus the client handshake to see
+if the incoming message is valid; if it is, then it computes a
+"server handshake" to send in reply.
+
+The client processes the server handshake, and either succeeds or fails.
+
+At this point, the client and the relay both have access to:
+  * CM (the message the client sent)
+  * SM (the message the relay sent)
+  * KS (a shared byte stream of arbitrary length, used to compute
+    keys to be used elsewhere in the protocol).
+
+Additionally, the client knows that CM was sent _only_ to the relay
+whose public onion key is B, and that KS is shared _only_ with that
+relay.
+
+The relay does not know which client participated in the handshake,
+but it does know that CM came from the same client that generated
+the key X, and that SM and KS were shared _only_ with that client.
+
+Both parties know that CM, SM, and KS were shared correctly, or not
+at all.
+
+Both parties know that they used the same verification string; if
+they did not, they do not learn what the verification string was.
+(This feature is required for HS handshakes.)
+
+# The handshake in detail
+
+## Notation
+
+We use the following notation:
+
+  * `|` -- concatenation
+  * `"..."` -- a byte string, with no terminating NUL.
+  * `ENCAP(s)` -- an encapsulation function.  We define this
+     as `htonll(len(s)) | s`.  (Note that `len(ENCAP(s)) = len(s) + 8`).
+  * `PARTITION(s, n1, n2, n3, ...)` -- a function that partitions a
+     bytestring `s` into chunks of length `n1`, `n2`, `n3`, and so
+     on. Extra data is put into a final chunk.  If `s` is not long
+     enough, the function fails.
+
+We require the following crypto operations:
+
+  * `KDF(s,t)` -- a tweakable key derivation function, returning a
+     keystream of arbitrary length.
+  * `H(s,t)` -- a tweakable hash function of output length
+     `DIGEST_LEN`.
+  * `MAC(k, msg, t)` -- a tweakable message-authentication-code function,
+     with key length `MAC_KEY_LEN` and output length `MAC_LEN`.
+  * `EXP(pk,sk)` -- our Diffie Hellman group operation, taking a
+     public key of length `PUB_KEY_LEN`.
+  * `KEYGEN()` -- our Diffie-Hellman keypair generation algorithm,
+    returning a (secret-key,public-key) pair.
+  * `ENC(k, m)` -- a stream cipher with key of length `ENC_KEY_LEN`.
+    `DEC(k, m)` is its inverse.
+
+Parameters:
+
+  * `PROTOID` -- a short protocol identifier
+  * `t_*` -- a set of "tweak" strings, used to derive distinct
+    hashes from a single hash function.
+  * `ID_LEN` -- the length of an identity key that uniquely identifies
+    a relay.
+
+Given our cryptographic operations and a set of tweak strings, we
+define:
+
+```
+H_foo(s) = H(s, t_foo)
+MAC_foo(k, msg) = MAC(k, msg, t_foo)
+KDF_foo(s) = KDF(s, t_foo)
+```
+
+See Appendix A.1 below for a set of instantiations for these operations
+and constants.
+
+## Client operation, phase 1
+
+The client knows:
+    B, ID -- the onion key and ID of the relay it wants to use.
+    CM -- the message that it wants to send as part of its
+           handshake.
+    VER -- a verification string.
+
+First, the client generates a single-use keypair:
+
+    x,X = KEYGEN()
+
+and computes:
+
+    Bx = EXP(B,x)
+    secret_input_phase1 = Bx | ID | X | B | PROTOID | ENCAP(VER)
+    phase1_keys = KDF_msgkdf(secret_input_phase1)
+    (ENC_K1, MAC_K1) = PARTITION(phase1_keys, ENC_KEY_LEN, MAC_KEY_LEN)
+
+    encrypted_msg = ENC(ENC_K1, CM)
+    msg_mac = MAC_msgmac(MAC_K1, ID | B | X | encrypted_msg)
+
+and sends:
+
+    NODEID      ID               [ID_LEN bytes]
+    KEYID       B                [PUB_KEY_LEN bytes]
+    CLIENT_PK   X                [PUB_KEY_LEN bytes]
+    MSG         encrypted_msg    [len(CM) bytes]
+    MAC         msg_mac          [last MAC_LEN bytes of message]
+
+The client remembers x, X, B, ID, Bx, and msg_mac.
+
+## Server operation
+
+The relay checks whether NODEID is as expected, and looks up
+the (b,B) keypair corresponding to KEYID.  If the keypair is
+missing or the NODEID is wrong, the handshake fails.
+
+Now the relay uses `X=CLIENT_PK` to compute:
+
+    Xb = EXP(X,b)
+    secret_input_phase1 = Xb | ID | X | B | PROTOID | ENCAP(VER)
+    phase1_keys = KDF_msgkdf(secret_input_phase1)
+    (ENC_K1, MAC_K1) = PARTITION(phase1_keys, ENC_KEY_LEN, MAC_KEY_LEN)
+
+    expected_mac = MAC_msgmac(MAC_K1, ID | B | X | MSG)
+
+If `expected_mac` is not `MAC`, the handshake fails.  Otherwise
+the relay computes `CM` as:
+
+    CM = DEC(MSG, ENC_K1)
+
+The relay then checks whether `CM` is well-formed, and in response
+composes `SM`, the reply that it wants to send as part of the
+handshake. It then generates a new ephemeral keypair:
+
+    y,Y = KEYGEN()
+
+and computes the rest of the handshake:
+
+    Xy = EXP(X,y)
+    secret_input = Xy | Xb | ID | B | X | Y | PROTOID | ENCAP(VER)
+    ntor_key_seed = H_key_seed(secret_input)
+    verify = H_verify(secret_input)
+
+    RAW_KEYSTREAM = KDF_final(ntor_key_seed)
+    (ENC_KEY, KEYSTREAM) = PARTITION(RAW_KEYSTREAM, ENC_KEY_LKEN, ...)
+
+    encrypted_msg = ENC(ENC_KEY, SM)
+
+    auth_input = verify | ID | B | Y | X | MAC | ENCAP(encrypted_msg) |
+        PROTOID | "Server"
+    AUTH = H_auth(auth_input)
+
+The relay then sends:
+
+    Y          Y              [PUB_KEY_LEN bytes]
+    AUTH       AUTH           [DIGEST_LEN bytes]
+    MSG        encrypted_msg  [len(SM) bytes, up to end of the message]
+
+The relay uses KEYSTREAM to generate the shared secrets for the
+newly created circuit.
+
+## Client operation, phase 2
+
+The client computes:
+
+    Yx = EXP(Y, x)
+    secret_input = Yx | Bx | ID | B | X | Y | PROTOID | ENCAP(VER)
+    ntor_key_seed = H_key_seed(secret_input)
+    verify = H_verify(secret_input)
+
+    auth_input = verify | ID | B | Y | X | MAC | ENCAP(MSG) |
+        PROTOID | "Server"
+    AUTH_expected = H_auth(auth_input)
+
+If AUTH_expected is equal to AUTH, then the handshake has
+succeeded.  The client can then calculate:
+
+    RAW_KEYSTREAM = KDF_final(ntor_key_seed)
+    (ENC_KEY, KEYSTREAM) = PARTITION(RAW_KEYSTREAM, ENC_KEY_LKEN, ...)
+
+    SM = DEC(ENC_KEY, MSG)
+
+SM is the message from the relay, and the client uses KEYSTREAM to
+generate the shared secrets for the newly created circuit.
+
+# Security notes
+
+Whenever comparing bytestrings, implementations SHOULD use
+constant-time comparison function to avoid side-channel attacks.
+
+To avoid small-subgroup attacks against the Diffie-Hellman function,
+implementations SHOULD either:
+
+   * Make sure that all incoming group members are in fact in the DH
+     group.
+   * Validate all outputs from the EXP function to make sure that
+     they are not degenerate.
+
+
+# Notes on usage
+
+We don't specify what should actually be done with the resulting
+keystreams; that depends on the usage for which this handshake is
+employed.  Typically, they'll be divided up into a series of tags
+and symmetric keys.
+
+The keystreams generated here are (conceptually) unlimited.  In
+practice, the usage will determine the amount of key material
+actually needed: that's the amount that clients and relays will
+actually generate.
+
+The PROTOID parameter should be changed not only if the
+cryptographic operations change here, but also if the usage changes
+at all, or if the meaning of any parameters changes.  (For example,
+if the encoding of CM and SM changed, or if ID were a different
+length or represented a different type of key, then we should start
+using a new PROTOID.)
+
+
+# A.1 Instantiation
+
+Here are a set of functions based on SHA3, SHAKE-256, Curve25519, and
+AES256:
+
+```
+H(s, t) = SHA3_256(ENCAP(t) | s)
+MAC(k, msg, t) = SHA3_256(ENCAP(t) | ENCAP(k) | s)
+KDF(s, t) = SHAKE_256(ENCAP(t) | s)
+ENC(k, m) = AES_256_CTR(k, m)
+
+EXP(pk,sk), KEYGEN: defined as in curve25519
+
+DIGEST_LEN = MAC_LEN = MAC_KEY_LEN = ENC_KEY_LEN = PUB_KEY_LEN = 32
+
+ID_LEN = 32  (representing an ed25519 identity key)
+```
+
+Notes on selected operations: SHA3 can be pretty slow, and AES256 is
+likely overkill.  I'm choosing them anyway because they are what we
+use in hs-ntor, and in my preliminary experiments they don't account
+for even 1% of the time spent on this handshake.
+
+```
+t_msgkdf = PROTOID | ":kdf_phase1"
+t_msgmac = PROTOID | ":msg_mac"
+t_key_seed = PROTOID | ":key_seed"
+t_verify = PROTOID | ":verify"
+t_final = PROTOID | ":kdf_final"
+t_auth = PROTOID | ":auth_final"
+```
+
+# A.2 Encoding for use with Tor circuit extension
+
+Here we give a concrete instantiation of ntor-v3 for use with
+circuit extension in Tor, and the parameters in A.1 above.
+
+If in use, this is a new CREATE2 type.  Clients should not use it
+unless the relay advertises support by including an appropriate
+version of the `Relay=X` subprotocol in its protocols list.
+
+When the encoding and methods of this section, along with the
+instantiations from the previous section, are in use, we specify:
+
+    PROTOID = "ntor3-curve25519-sha3_256-1"
+
+The key material is extracted as follows, unless modified by the
+handshake (see below).  See tor-spec.txt for more info on the
+specific values:
+
+    Df    Digest authentication, forwards  [20 bytes]
+    Db    Digest authentication, backwards [20 bytes]
+    Kf    Encryption key, forwards         [16 bytes]
+    Kb    Encryption key, backwards        [16 bytes]
+    KH    Onion service nonce              [20 bytes]
+
+We use the following meta-encoding for the contents of client and
+server messages.
+
+    [Any number of times]:
+    EXTENSION
+       EXT_FIELD_TYPE     [one byte]
+       EXT_FIELD_LEN      [one byte]
+       EXT_FIELD          [EXT_FIELD_LEN bytes]
+
+(`EXT_FIELD_LEN` may be zero, in which case EXT_FIELD is absent.)
+
+All parties MUST reject messages that are not well-formed per the
+rules above.
+
+We do not specify specific TYPE semantics here; we leave those for
+other proposals and specifications.
+
+Parties MUST ignore extensions with `EXT_FIELD_TYPE` bodies they do not
+recognize.
+
+Unless otherwise specified in the documentation for an extension type:
+* Each extension type SHOULD be sent only once in a message.
+* Parties MUST ignore any occurrences all occurrences of an extension
+  with a given type after the first such occurrence.
+* Extensions SHOULD be sent in numerically ascending order by type.
+
+(The above extension sorting and multiplicity rules are only defaults;
+they may be overridden in the description of individual extensions.)
+
+# A.3 How much space is available?
+
+We start with a 498-byte payload in each relay cell.
+
+The header of the EXTEND2 cell, including link specifiers and other
+headers, comes to 89 bytes.
+
+The client handshake requires 128 bytes (excluding CM).
+
+That leaves 281 bytes, "which should be plenty".
+
+# X.1 Negotiating proposal-324 circuit windows
+
+(We should move this section into prop324 when this proposal is
+finished.)
+
+We define a type value, CIRCWINDOW_INC.
+
+We define a triplet of consensus parameters: `circwindow_inc_min`,
+`cincwindow_inc_max`, and `circwindow_inc_dflt`.  These all have
+range (1,65535).
+
+When the authority operators want to experiment with different
+values for `circwindow_inc_dflt`, they set `circwindow_inc_min` and
+`circwindow_inc_max` to the range in which they want to experiment,
+making sure that the existing `circwindow_inc_dflt` is within that
+range.
+
+vWhen a client sees that a relay supports the ntor3 handshake type
+(subprotocol `Relay=X`), and also supports the flow control
+algorithms of proposal 324 (subprotocol `FlowCtrl=X`), then the
+client sends a message, with type `CIRCWINDOW_INC`, containing a
+two-byte integer equal to `circwindow_inc_dflt`.
+
+The relay rejects the message if the value given is outside of the
+\[`circwindow_inc_min`, `circwindow_inc_max`\] range.  Otherwise, it
+accepts it, and replies with the same message that the client sent.
+
+# X.2: Test vectors
+
+The following test values, in hex, were generated by a Python reference
+implementation.
+
+Inputs:
+
+b = "4051daa5921cfa2a1c27b08451324919538e79e788a81b38cbed097a5dff454a"
+B = "f8307a2bc1870b00b828bb74dbb8fd88e632a6375ab3bcd1ae706aaa8b6cdd1d"
+ID = "9fad2af287ef942632833d21f946c6260c33fae6172b60006e86e4a6911753a2"
+x = "b825a3719147bcbe5fb1d0b0fcb9c09e51948048e2e3283d2ab7b45b5ef38b49"
+X = "252fe9ae91264c91d4ecb8501f79d0387e34ad8ca0f7c995184f7d11d5da4f46"
+CM = "68656c6c6f20776f726c64"
+VER = "78797a7a79"
+y = "4865a5b7689dafd978f529291c7171bc159be076b92186405d13220b80e2a053"
+Y = "4bf4814326fdab45ad5184f5518bd7fae25dc59374062698201a50a22954246d"
+SM = "486f6c61204d756e646f"
+
+Intermediate values:
+
+ENC_K1 = "4cd166e93f1c60a29f8fb9ec40ea0fc878930c27800594593e1c4d0f3b5fbd02"
+MAC_K1 = "f5b69e85fdd26e1b0bdbbc8128e32d8123040255f11f744af3cc98fc13613cda"
+msg_mac = "9e044d53565f04d82bbb3bebed3d06cea65db8be9c72b68cd461942088502f67"
+key_seed = "b9a092741098e1f5b8ab37ce74399dd57522c974d7ae4626283a1077b9273255"
+verify = "1dc09fb249738a79f1bc3a545eee8c415f27213894a760bb4df58862e414799a"
+ENC_KEY (server) = "cab8a93eef62246a83536c4384f331ec26061b66098c61421b6cae81f4f57c56"
+AUTH = "2fc5f8773ca824542bc6cf6f57c7c29bbf4e5476461ab130c5b18ab0a9127665"
+
+Messages:
+
+client_handshake = "9fad2af287ef942632833d21f946c6260c33fae6172b60006e86e4a6911753a2f8307a2bc1870b00b828bb74dbb8fd88e632a6375ab3bcd1ae706aaa8b6cdd1d252fe9ae91264c91d4ecb8501f79d0387e34ad8ca0f7c995184f7d11d5da4f463bebd9151fd3b47c180abc9e044d53565f04d82bbb3bebed3d06cea65db8be9c72b68cd461942088502f67"
+
+server_handshake = "4bf4814326fdab45ad5184f5518bd7fae25dc59374062698201a50a22954246d2fc5f8773ca824542bc6cf6f57c7c29bbf4e5476461ab130c5b18ab0a91276651202c3e1e87c0d32054c"
+
+First 256 bytes of keystream:
+
+KEYSTREAM = "9c19b631fd94ed86a817e01f6c80b0743a43f5faebd39cfaa8b00fa8bcc65c3bfeaa403d91acbd68a821bf6ee8504602b094a254392a07737d5662768c7a9fb1b2814bb34780eaee6e867c773e28c212ead563e98a1cd5d5b4576f5ee61c59bde025ff2851bb19b721421694f263818e3531e43a9e4e3e2c661e2ad547d8984caa28ebecd3e4525452299be26b9185a20a90ce1eac20a91f2832d731b54502b09749b5a2a2949292f8cfcbeffb790c7790ed935a9d251e7e336148ea83b063a5618fcff674a44581585fd22077ca0e52c59a24347a38d1a1ceebddbf238541f226b8f88d0fb9c07a1bcd2ea764bbbb5dacdaf5312a14c0b9e4f06309b0333b4a"


### PR DESCRIPTION
Implement the o5 handshake based on pq-obfs. 

Currently implemented and tested for <mlkem768, sha3-256> as the `kemeleon::OKemCore` implementation for x25519 and XWing are incomplete.


The image below contains most, **BUT NOT ALL** details about the handshake.
![pq-obfs_neg_annotated](https://github.com/user-attachments/assets/3268d009-8de8-48e2-a81e-24dfd0f544d3)
